### PR TITLE
Configure ruff linting with comprehensive rule sets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,53 @@ dev = [
 line-length = 140
 target-version = "py311"
 
+[tool.ruff.lint]
+# Enable common linting rules
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "N",      # pep8-naming
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "S",      # flake8-bandit (security)
+    "C4",     # flake8-comprehensions
+    "DTZ",    # flake8-datetimez
+    "T10",    # flake8-debugger
+    "EM",     # flake8-errmsg
+    "ISC",    # flake8-implicit-str-concat
+    "ICN",    # flake8-import-conventions
+    "PIE",    # flake8-pie
+    "PT",     # flake8-pytest-style
+    "Q",      # flake8-quotes
+    "RSE",    # flake8-raise
+    "RET",    # flake8-return
+    "SIM",    # flake8-simplify
+    "TID",    # flake8-tidy-imports
+    "ARG",    # flake8-unused-arguments
+    "PTH",    # flake8-use-pathlib
+    "PL",     # pylint
+    "RUF",    # Ruff-specific rules
+]
+
+# Ignore specific rules that may be too strict
+ignore = [
+    "S101",   # Use of assert detected (useful in tests)
+    "PLR0913", # Too many arguments to function call
+    "PLR2004", # Magic value used in comparison
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Allow assert statements and other test-specific patterns in tests
+"tests/**/*.py" = ["S101", "PLR2004", "ARG001"]
+
+[tool.ruff.format]
+# Use black-compatible formatting
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]


### PR DESCRIPTION
- Enable black-compatible formatting rules
- Enable bandit security checks (S rules)
- Enable standard linting rules: pycodestyle, pyflakes, isort, pep8-naming, pyupgrade, bugbear, and more
- Add per-file ignores for test files
- Configure ruff formatter with black-compatible settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)