### PR TITLE
docs: Promote uv as primary installation method on README and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,27 @@ A [Python](https://www.python.org) TUI (Terminal User Interface) client for the 
 
 ## Installation
 
-### From PyPI (Recommended)
+### From PyPI (Recommended with uv)
 
 ```bash
-pip install miniflux-tui-py
+# Install uv if you haven't already
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install miniflux-tui-py
+uv tool install miniflux-tui-py
 
 # Create configuration
 miniflux-tui --init
 
 # Run the application
+miniflux-tui
+```
+
+### Alternative: Using pip
+
+```bash
+pip install miniflux-tui-py
+miniflux-tui --init
 miniflux-tui
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,14 @@ A Python Terminal User Interface (TUI) client for [Miniflux](https://miniflux.ap
 
 ## Quick Start
 
-### Installation
+### Installation (Recommended with uv)
 
 ```bash
-pip install miniflux-tui-py
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install miniflux-tui-py
+uv tool install miniflux-tui-py
 ```
 
 ### Configuration
@@ -38,6 +42,8 @@ This will prompt you for your Miniflux server URL and API key.
 ```bash
 miniflux-tui
 ```
+
+See the [Installation Guide](installation.md) for more options including pip and source installation.
 
 ## Key Bindings
 


### PR DESCRIPTION
## Summary
This PR promotes uv as the recommended installation method on all user-facing documentation pages (GitHub README and documentation homepage).

## Changes
- **README.md** (GitHub front page): uv tool install is now the primary recommendation
- **docs/index.md** (Documentation homepage): uv promoted in Quick Start section
- Both include alternative pip option for users who prefer it
- Clear links to Installation Guide for more options

## Context
All other documentation (installation.md, contributing.md, CLAUDE.md) already promote uv. This ensures consistent messaging across all user entry points.

## Testing
- ✓ All pre-commit hooks pass
- ✓ Documentation formatting correct