### PR TITLE
fix: Add GitHub Actions permissions and fix linting issues

### DIFF
--- a/.github/DEPENDABOT.md
+++ b/.github/DEPENDABOT.md
@@ -53,11 +53,12 @@ If Dependabot updates cause issues:
 1. **Close the PR** and wait for next week's update
 2. **Check the issue** - usually reported in PR comments
 3. **Pin the version** in `pyproject.toml` if needed:
-   ```toml
-   dependencies = [
-       "textual>=0.82.0,<0.83.0",  # Pin to avoid breaking changes
-   ]
-   ```
+
+    ```toml
+    dependencies = [
+        "textual>=0.82.0,<0.83.0",  # Pin to avoid breaking changes
+    ]
+    ```
 
 ### GitHub Actions Updates
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/docs/api/screens.md
+++ b/docs/api/screens.md
@@ -93,7 +93,7 @@ MinifluxTUI (App)
 │  ├─ navigate with J/K
 │  └─ press Escape → back to EntryListScreen
 └─ HelpScreen (help view)
-   └─ press any key → back to previous screen
+  └─ press any key → back to previous screen
 ```
 
 ## Widget Classes


### PR DESCRIPTION
## Summary

Follow-up to PR #20 to address linting issues that were flagged by the super-linter workflow.

**Changes:**
- Add top-level `permissions: {contents: read}` to `.github/workflows/test.yml` and `.github/workflows/publish.yml` to resolve Checkov security check CKV2_GHA_1
- Fix EditorConfig indentation in `.github/DEPENDABOT.md` (code block indentation)
- Fix EditorConfig indentation in `docs/api/screens.md` (tree structure formatting)

**Why needed:**
- GitHub Actions workflows require explicit permissions to pass Checkov security checks
- EditorConfig requires indentation to be multiples of 2 spaces

## Test Plan

- Run pre-commit hooks: `pre-commit run --all-files` - should pass all checks
- Run linter workflow locally if possible: `docker run --rm -v $(pwd):/workspace ghcr.io/super-linter/super-linter:slim-v7.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)