### PR TITLE
docs: Promote uv as primary installation method on all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,27 @@ A [Python](https://www.python.org) TUI (Terminal User Interface) client for the 
 
 ## Installation
 
-### From PyPI (Recommended)
+### From PyPI (Recommended with uv)
 
 ```bash
-pip install miniflux-tui-py
+# Install uv if you haven't already
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install miniflux-tui-py
+uv tool install miniflux-tui-py
 
 # Create configuration
 miniflux-tui --init
 
 # Run the application
+miniflux-tui
+```
+
+### Alternative: Using pip
+
+```bash
+pip install miniflux-tui-py
+miniflux-tui --init
 miniflux-tui
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,14 @@ A Python Terminal User Interface (TUI) client for [Miniflux](https://miniflux.ap
 
 ## Quick Start
 
-### Installation
+### Installation (Recommended with uv)
 
 ```bash
-pip install miniflux-tui-py
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install miniflux-tui-py
+uv tool install miniflux-tui-py
 ```
 
 ### Configuration
@@ -38,6 +42,8 @@ This will prompt you for your Miniflux server URL and API key.
 ```bash
 miniflux-tui
 ```
+
+See the [Installation Guide](installation.md) for more options including pip and source installation.
 
 ## Key Bindings
 


### PR DESCRIPTION
- Update README.md (GitHub front page) to show uv tool install as recommended
- Keep pip as alternative option
- Update docs/index.md Quick Start to promote uv
- Add link to Installation Guide for more options
- Ensures consistent messaging across all user-facing documentation