### PR TITLE
chore: Add coverage.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Thumbs.db
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 *.cover
 


### PR DESCRIPTION
Excludes coverage.xml from version control to avoid committing generated test artifacts.