### PR TITLE
fix: Resolve type checking errors for pyright

### DIFF
--- a/miniflux_tui/ui/screens/entry_reader.py
+++ b/miniflux_tui/ui/screens/entry_reader.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class EntryReaderScreen(Screen):
     """Screen for reading a single feed entry."""
 
-    BINDINGS = [  # noqa: RUF012
+    BINDINGS: list[Binding] = [  # noqa: RUF012
         Binding("j", "scroll_down", "Scroll Down", show=False),
         Binding("k", "scroll_up", "Scroll Up", show=False),
         Binding("J", "next_entry", "Next Entry", show=True),

--- a/miniflux_tui/ui/screens/help.py
+++ b/miniflux_tui/ui/screens/help.py
@@ -10,7 +10,7 @@ from textual.widgets import Footer, Header, Static
 class HelpScreen(Screen):
     """Screen displaying keyboard shortcuts and help information."""
 
-    BINDINGS = [  # noqa: RUF012
+    BINDINGS: list[Binding] = [  # noqa: RUF012
         Binding("escape", "close", "Close"),
         Binding("q", "close", "Close"),
     ]

--- a/tests/test_entry_reader.py
+++ b/tests/test_entry_reader.py
@@ -1,7 +1,7 @@
 """Tests for entry reader screen."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from textual.binding import Binding
@@ -183,11 +183,6 @@ class TestEntryReaderScreenActions:
         """Test mark_unread action."""
         screen = EntryReaderScreen(entry=sample_entry)
 
-        mock_app = MagicMock()
-        mock_client = AsyncMock()
-        mock_app.client = mock_client
-        screen._app = mock_app
-
         assert hasattr(screen, "action_mark_unread")
         assert callable(screen.action_mark_unread)
 
@@ -196,11 +191,6 @@ class TestEntryReaderScreenActions:
         """Test toggle_star action."""
         screen = EntryReaderScreen(entry=sample_entry)
 
-        mock_app = MagicMock()
-        mock_client = AsyncMock()
-        mock_app.client = mock_client
-        screen._app = mock_app
-
         assert hasattr(screen, "action_toggle_star")
         assert callable(screen.action_toggle_star)
 
@@ -208,11 +198,6 @@ class TestEntryReaderScreenActions:
     async def test_action_save_entry(self, sample_entry):
         """Test save_entry action."""
         screen = EntryReaderScreen(entry=sample_entry)
-
-        mock_app = MagicMock()
-        mock_client = AsyncMock()
-        mock_app.client = mock_client
-        screen._app = mock_app
 
         assert hasattr(screen, "action_save_entry")
         assert callable(screen.action_save_entry)
@@ -230,11 +215,6 @@ class TestEntryReaderScreenActions:
     async def test_action_fetch_original(self, sample_entry):
         """Test fetch_original action."""
         screen = EntryReaderScreen(entry=sample_entry)
-
-        mock_app = MagicMock()
-        mock_client = AsyncMock()
-        mock_app.client = mock_client
-        screen._app = mock_app
 
         assert hasattr(screen, "action_fetch_original")
         assert callable(screen.action_fetch_original)
@@ -273,9 +253,6 @@ class TestEntryReaderScreenActions:
         """Test back action."""
         screen = EntryReaderScreen(entry=sample_entry)
 
-        mock_app = MagicMock()
-        screen._app = mock_app
-
         assert hasattr(screen, "action_back")
         assert callable(screen.action_back)
 
@@ -283,18 +260,12 @@ class TestEntryReaderScreenActions:
         """Test show_help action."""
         screen = EntryReaderScreen(entry=sample_entry)
 
-        mock_app = MagicMock()
-        screen._app = mock_app
-
         assert hasattr(screen, "action_show_help")
         assert callable(screen.action_show_help)
 
     def test_action_quit(self, sample_entry):
         """Test quit action."""
         screen = EntryReaderScreen(entry=sample_entry)
-
-        mock_app = MagicMock()
-        screen._app = mock_app
 
         assert hasattr(screen, "action_quit")
         assert callable(screen.action_quit)


### PR DESCRIPTION
Fixes all 17 pyright type checking errors preventing releases:

- Add explicit type hints to BINDINGS in help.py and entry_reader.py
- Remove invalid _app attribute assignments in tests
- All 215 tests pass
- 56% test coverage maintained