### PR TITLE
Fix GitHub Actions release job to include artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Download artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist/
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

The release job in `.github/workflows/publish.yml` was attempting to attach distribution packages to GitHub Releases, but wasn't downloading the artifacts from the build job. This caused releases to be created without the `.tar.gz` and `.whl` distribution files.

## Changes

- Added `actions/download-artifact` step to the release job
- Downloads the `dist/` artifacts built by the build job
- Ensures GitHub Releases include distribution packages

## Testing

Next release will:
1. Build packages in the build job ✅
2. Publish to PyPI in the publish job ✅
3. Create GitHub Release with distribution files ✅

Fixes the automated release workflow to properly attach built packages to GitHub Releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)