### PR TITLE
Fix GitHub Release job permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Problem

The GitHub Release job was failing with:
```
X Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```

This happened because the release job didn't have write permissions to create releases.

## Root Cause

- Top-level workflow permissions: `contents: read`
- Release job had no explicit permissions, so it inherited the default
- Creating GitHub Releases requires `contents: write` permission

## Solution

Added explicit `permissions: contents: write` to the release job, allowing it to create GitHub Releases and attach distribution artifacts.

## Impact

After this fix, the complete release workflow will work:
1. ✅ Build and test code
2. ✅ Publish to PyPI
3. ✅ Create GitHub Release with artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)