### PR TITLE
Add Python 3.15 preview testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   test:
+    name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,3 +54,37 @@ jobs:
             exit 1
           fi
           echo "Coverage $coverage_percent% meets threshold $threshold%"
+
+  test-future:
+    name: Test Python 3.15 (Preview)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python 3.15
+        run: uv python install 3.15
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Check formatting with ruff
+        run: uv run ruff check miniflux_tui tests
+
+      - name: Type check with pyright
+        run: uv run pyright miniflux_tui tests
+
+      - name: Run tests with coverage
+        run: uv run pytest tests --cov=miniflux_tui --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Added a separate job to test against Python 3.15 without blocking releases. This enables early compatibility testing while maintaining a stable CI/CD pipeline.

## How It Works

**Two separate jobs:**
- `test` (Required): Tests Python 3.11, 3.12, 3.13, 3.14
  - Must pass for release
  - Blocks PR if any version fails
- `test-future` (Optional): Tests Python 3.15 only
  - `continue-on-error: true` - doesn't block workflow
  - Runs same checks but failures don't fail the job
  - You'll still see failures in the UI for visibility

## Benefits

✅ **Early Warning**: Get notifications about Python 3.15 compatibility issues early  
✅ **Non-blocking**: Issues don't prevent releases  
✅ **Visibility**: Failures are visible in GitHub but don't block  
✅ **Gradual Migration**: Time to fix issues before Python 3.15 becomes stable  
✅ **Automatic**: No manual configuration needed as Python 3.15 becomes available  

## What Happens

Each push to main:
1. Stable Python versions (3.11-3.14) test - **MUST PASS**
2. Future Python version (3.15) test - **NICE TO HAVE**

If Python 3.15 test fails, GitHub will:
- Show a ⚠️ warning icon (not ❌ failure)
- Display the failure details
- But won't block the workflow
- You can still merge and release

## Example Scenarios

| Scenario | 3.11-3.14 | 3.15 | Result |
|----------|-----------|------|--------|
| All pass | ✅ | ✅ | Green check |
| Stable fails | ❌ | ✅ | Blocked (don't release) |
| Stable pass, 3.15 fails | ✅ | ⚠️ | Green (but fix 3.15 issues) |
| All fail | ❌ | ❌ | Blocked |

🤖 Generated with [Claude Code](https://claude.com/claude-code)