### PR TITLE
fix: Resolve linting errors and fix navigation persistence after reading entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   # Enable version updates for Python dependencies (via uv)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,4 @@
+---
 name: Dependabot Auto-Merge
 
 on:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,3 +1,4 @@
+---
 name: Deploy Docs to GitHub Pages
 
 on:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -3,12 +3,14 @@
 name: OSV-Scanner Vulnerability Scan
 
 on:
-  # Change "main" to your default branch if you use a different name, i.e. "master"
+  # Change "main" to your default branch if you use a different name
+  # i.e. "master"
   push:
     branches: [main]
 
 permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  # Required to upload SARIF file to CodeQL.
+  # See: https://github.com/github/codeql-action/issues/2117
   actions: read
   # Require writing security events to upload SARIF file to security tab
   security-events: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+---
 name: Publish to PyPI
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test Python Versions
 
 on:
@@ -34,7 +35,9 @@ jobs:
         run: uv run pyright miniflux_tui tests
 
       - name: Run tests with coverage
-        run: uv run pytest tests --cov=miniflux_tui --cov-report=xml --cov-report=term-missing
+        run: |
+          uv run pytest tests --cov=miniflux_tui --cov-report=xml \
+            --cov-report=term-missing
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -47,7 +50,10 @@ jobs:
 
       - name: Check coverage threshold
         run: |
-          coverage_percent=$(python -c "import xml.etree.ElementTree as ET; root = ET.parse('coverage.xml').getroot(); print(float(root.get('line-rate')) * 100)")
+          coverage_percent=$(python -c \
+            "import xml.etree.ElementTree as ET; \
+            root = ET.parse('coverage.xml').getroot(); \
+            print(float(root.get('line-rate')) * 100)")
           threshold=55
           if (( $(echo "$coverage_percent < $threshold" | bc -l) )); then
             echo "Coverage $coverage_percent% is below threshold $threshold%"
@@ -78,7 +84,9 @@ jobs:
         run: uv run pyright miniflux_tui tests
 
       - name: Run tests with coverage
-        run: uv run pytest tests --cov=miniflux_tui --cov-report=xml --cov-report=term-missing
+        run: |
+          uv run pytest tests --cov=miniflux_tui --cov-report=xml \
+            --cov-report=term-missing
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,7 +60,7 @@ python scripts/release.py
 ```
 
 You'll see:
-```
+```text
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 miniflux-tui-py Release Script
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -72,12 +72,12 @@ Enter new version (e.g., 0.2.1):
 ### 2. Enter New Version
 
 Type the new version using semantic versioning:
-  - `0.2.1` for patch release (bug fixes)
-  - `0.3.0` for minor release (new features)
-  - `1.0.0` for major release (breaking changes)
+- `0.2.1` for patch release (bug fixes)
+- `0.3.0` for minor release (new features)
+- `1.0.0` for major release (breaking changes)
 
 Example:
-```
+```text
 New version: 0.2.1
 ✓ Version validated: 0.2.1
 ```
@@ -120,7 +120,7 @@ The script will:
 - ✓ Create a git tag
 - ✓ Push to GitHub
 
-```
+```text
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Release Complete! 🚀
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -136,31 +136,31 @@ PyPI:         https://pypi.org/project/miniflux-tui-py/0.2.1/
 Once you push the tag, GitHub Actions automatically:
 
 1. **Build Job** (in parallel)
-  - Checks out code
-  - Runs ruff linting
-  - Runs pyright type checking
-  - Runs pytest (215 tests)
-  - Builds distribution packages (tar.gz + wheel)
+- Checks out code
+- Runs ruff linting
+- Runs pyright type checking
+- Runs pytest (215 tests)
+- Builds distribution packages (tar.gz + wheel)
 
 2. **Publish Job** (after build succeeds)
-  - Downloads artifacts
-  - Publishes to PyPI using Trusted Publisher
-  - No secrets required!
+- Downloads artifacts
+- Publishes to PyPI using Trusted Publisher
+- No secrets required!
 
 3. **Release Job** (after build succeeds)
-  - Creates GitHub Release
-  - Attaches distribution artifacts
-  - Auto-generates release notes
+- Creates GitHub Release
+- Attaches distribution artifacts
+- Auto-generates release notes
 
 ### 7. Verify Release
 
 Monitor the workflow:
-```
+```text
 https://github.com/reuteras/miniflux-tui-py/actions
 ```
 
 Check PyPI (usually within 1-2 minutes):
-```
+```text
 https://pypi.org/project/miniflux-tui-py/
 ```
 
@@ -174,14 +174,14 @@ uv add miniflux-tui-py==0.2.1
 
 For automatic PyPI publishing without storing secrets:
 
-1. Go to https://pypi.org/account/publishing/
+1. Go to [https://pypi.org/account/publishing/](https://pypi.org/account/publishing/)
 2. Click "Add a new trusted publisher"
 3. Fill in:
-  - **PyPI Project Name:** `miniflux-tui-py`
-  - **GitHub Repository Owner:** `reuteras`
-  - **GitHub Repository Name:** `miniflux-tui-py`
-  - **Workflow Filename:** `publish.yml`
-  - **Environment Name:** `pypi`
+- **PyPI Project Name:** `miniflux-tui-py`
+- **GitHub Repository Owner:** `reuteras`
+- **GitHub Repository Name:** `miniflux-tui-py`
+- **Workflow Filename:** `publish.yml`
+- **Environment Name:** `pypi`
 4. Click "Add trusted publisher"
 
 That's it! No API tokens needed.
@@ -190,7 +190,7 @@ That's it! No API tokens needed.
 
 ### Tests Failed
 
-```
+```text
 ✗ Tests failed. Fix issues before releasing.
 ```
 
@@ -202,7 +202,7 @@ uv run pytest tests --cov=miniflux_tui
 
 ### Linting Failed
 
-```
+```text
 ✗ Linting failed. Run 'uv run ruff check miniflux_tui tests' to see issues.
 ```
 
@@ -214,7 +214,7 @@ uv run ruff format miniflux_tui tests  # Auto-format
 
 ### Type Checking Failed
 
-```
+```text
 ✗ Type checking failed. Run 'uv run pyright miniflux_tui tests' to see issues.
 ```
 
@@ -226,7 +226,7 @@ uv run pyright miniflux_tui tests
 
 ### Working Directory Not Clean
 
-```
+```text
 ✗ Working directory is not clean. Please commit or stash changes first.
 ```
 
@@ -240,7 +240,7 @@ git commit -m "Your message"
 
 ### CHANGELOG Not Updated
 
-```
+```text
 ✗ CHANGELOG.md was not updated
 ```
 
@@ -250,7 +250,7 @@ The script will revert the version change. Edit `CHANGELOG.md` manually, then ru
 ### GitHub Actions Failed
 
 Check the workflow logs at:
-```
+```text
 https://github.com/reuteras/miniflux-tui-py/actions
 ```
 
@@ -264,19 +264,19 @@ Common issues:
 Use **Semantic Versioning** (MAJOR.MINOR.PATCH):
 
 - **PATCH** (0.2.1): Bug fixes, no new features
-  ```bash
-  # Example: 0.2.0 → 0.2.1
-  ```
+```bash
+# Example: 0.2.0 → 0.2.1
+```
 
 - **MINOR** (0.3.0): New features, backward compatible
-  ```bash
-  # Example: 0.2.0 → 0.3.0
-  ```
+```bash
+# Example: 0.2.0 → 0.3.0
+```
 
 - **MAJOR** (1.0.0): Breaking changes
-  ```bash
-  # Example: 0.2.0 → 1.0.0
-  ```
+```bash
+# Example: 0.2.0 → 1.0.0
+```
 
 ## Release Checklist
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security vulnerability in miniflux-tui-py, please **do not** create a public GitHub issue. Instead, please report it privately by emailing:
 
-**peter@reuteras.net**
+**[peter@reuteras.net](mailto:peter@reuteras.net)**
 
 Please include:
 1. A description of the vulnerability
@@ -74,7 +74,7 @@ We follow responsible disclosure practices and ask that you:
 
 ## Security Contact
 
-- **Email**: peter@reuteras.net
+- **Email**: [peter@reuteras.net](mailto:peter@reuteras.net)
 - **Response Time**: We aim to acknowledge reports within 48 hours
 
 Thank you for helping keep miniflux-tui-py and its users secure!

--- a/miniflux_tui/ui/screens/entry_list.py
+++ b/miniflux_tui/ui/screens/entry_list.py
@@ -122,6 +122,7 @@ class EntryListScreen(Screen):
         self.feed_header_map: dict[str, FeedHeaderItem] = {}  # Map feed names to header items
         self.feed_fold_state: dict[str, bool] = {}  # Track fold state per feed (True = expanded)
         self.last_highlighted_feed: str | None = None  # Track last highlighted feed for position persistence
+        self.last_cursor_index: int = 0  # Track cursor position for non-grouped mode
 
     @property
     def app(self) -> "MinifluxTUI":
@@ -158,10 +159,8 @@ class EntryListScreen(Screen):
         if self.entries and self.list_view:
             self._populate_list()
             # Use call_later to defer focus and cursor restoration until ListView has updated
-            if self.group_by_feed:
-                self.call_later(self._restore_cursor_position_and_focus)
-            else:
-                self.call_later(self._ensure_focus)
+            # Always restore cursor position to maintain user's navigation context
+            self.call_later(self._restore_cursor_position_and_focus)
         elif self.list_view and len(self.list_view.children) > 0:
             # If no entries, just ensure focus
             self.call_later(self._ensure_focus)
@@ -172,6 +171,10 @@ class EntryListScreen(Screen):
         if event.item and isinstance(event.item, EntryListItem):
             # Save the feed of the current entry for position restoration
             self.last_highlighted_feed = event.item.entry.feed.title
+
+            # Save the cursor index in the list view
+            if self.list_view:
+                self.last_cursor_index = self.list_view.index
 
             # Find the index of this entry in the sorted entry list
             entry_index = 0
@@ -201,15 +204,17 @@ class EntryListScreen(Screen):
                 self.list_view.index = 0
 
     def _restore_cursor_position(self) -> None:
-        """Restore cursor position to the last highlighted feed header.
+        """Restore cursor position based on mode.
 
+        In grouped mode: restore position to the last highlighted feed header.
+        In non-grouped mode: restore position to the last cursor index.
         Used after rebuilding the list to restore user's position.
         """
-        if not self.list_view or not self.last_highlighted_feed:
+        if not self.list_view:
             return
 
-        # Try to find the feed header in the new list
-        if self.last_highlighted_feed in self.feed_header_map:
+        # In grouped mode, try to restore to the last highlighted feed
+        if self.group_by_feed and self.last_highlighted_feed and self.last_highlighted_feed in self.feed_header_map:
             feed_header = self.feed_header_map[self.last_highlighted_feed]
             # Find its index in the list view
             for i, child in enumerate(self.list_view.children):
@@ -218,9 +223,16 @@ class EntryListScreen(Screen):
                         self.list_view.index = i
                         return
 
-        # If not found, just go to first item
-        with suppress(Exception):
-            self.list_view.index = 0
+        # In non-grouped mode or if feed not found, use last cursor index
+        max_index = len(self.list_view.children) - 1
+        if max_index >= 0:
+            cursor_index = min(self.last_cursor_index, max_index)
+            with suppress(Exception):
+                self.list_view.index = cursor_index
+        else:
+            # If not found, just go to first item
+            with suppress(Exception):
+                self.list_view.index = 0
 
     def _restore_cursor_position_and_focus(self) -> None:
         """Restore cursor position and ensure focus (called after ListView update)."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+---
 site_name: miniflux-tui-py
 site_description: A Python TUI client for Miniflux RSS reader
 repo_url: https://github.com/reuteras/miniflux-tui-py
@@ -58,6 +59,6 @@ nav:
   - Usage: usage.md
   - Contributing: contributing.md
   - API Reference:
-    - Client: api/client.md
-    - Models: api/models.md
-    - Screens: api/screens.md
+      - Client: api/client.md
+      - Models: api/models.md
+      - Screens: api/screens.md


### PR DESCRIPTION
## Summary

This PR fixes critical linting errors found in GitHub Actions checks and addresses a UX bug where cursor position was lost when returning from the entry reader.

## Changes

### Markdown Linting Fixes
- **RELEASE.md**: 
  - Added language specifiers to code fences (fixes MD040)
  - Fixed unordered list indentation (fixes MD007)
  - Wrapped bare URLs in markdown links (fixes MD034)
- **SECURITY.md**:
  - Wrapped bare URLs in markdown links (fixes MD034)

### YAML Linting Fixes
- Added document start markers (`---`) to all YAML files that were missing them
- Fixed indentation in mkdocs.yml nav section
- Split long lines in workflow files to comply with 80-character limit

### Navigation Bug Fix
Fixed issue where cursor position was not preserved when returning from the entry reader:
- Added `last_cursor_index` field to track cursor position in non-grouped mode
- Store cursor index when opening entry reader via `on_list_view_selected`
- Always restore cursor position on `on_screen_resume` regardless of grouping mode
- Updated `_restore_cursor_position()` to handle both grouped and non-grouped modes

## Test Plan

- [ ] Run `uv run ruff check .` - all checks should pass
- [ ] Run GitHub Actions Code Quality Checks - should pass without linting errors
- [ ] Test navigation: Open an entry, then press 'b' to go back. Cursor should be in the same position as before.
- [ ] Test in both grouped and non-grouped modes

## Related Issues

Fixes linting failures in Code Quality Checks workflow.
Fixes navigation issue where cursor position was lost after reading an entry.