### PR TITLE
feat: Add refresh all feeds operation for v0.5.0 (Issue #55)

### DIFF
--- a/miniflux_tui/ui/screens/entry_list.py
+++ b/miniflux_tui/ui/screens/entry_list.py
@@ -113,8 +113,9 @@ class EntryListScreen(Screen):
         Binding("l", "expand_feed", "Expand Feed"),
         Binding("left", "collapse_feed", "Collapse Feed", show=False),
         Binding("right", "expand_feed", "Expand Feed", show=False),
-        Binding("r", "refresh", "Refresh"),
-        Binding("comma", "refresh", "Refresh", show=False),
+        Binding("r", "refresh", "Refresh Feed"),
+        Binding("comma", "refresh", "Refresh Feed", show=False),
+        Binding("shift+r", "refresh_all_feeds", "Refresh All"),
         Binding("u", "show_unread", "Unread"),
         Binding("t", "show_starred", "Starred"),
         Binding("slash", "search", "Search"),
@@ -874,12 +875,33 @@ class EntryListScreen(Screen):
         self.notify("All feeds collapsed")
 
     async def action_refresh(self):
-        """Refresh the entry list from API."""
+        """Refresh the entry list from API (current view)."""
         if hasattr(self.app, "load_entries"):
             self.notify("Refreshing entries...")
             # Reload entries from API (this will fetch only unread entries)
             await self.app.load_entries(self.app.current_view)
             self.notify("Entries refreshed")
+
+    async def action_refresh_all_feeds(self):
+        """Refresh all feeds on the server (Issue #55 - Feed operations)."""
+        if not hasattr(self.app, "client") or not self.app.client:
+            self.notify("API client not initialized", severity="error")
+            return
+
+        try:
+            self.notify("Refreshing all feeds...")
+            await self.app.client.refresh_all_feeds()
+            self.notify("All feeds refreshed on server")
+
+            # Reload entries after refreshing all feeds
+            if hasattr(self.app, "load_entries"):
+                self.notify("Reloading entries...")
+                await self.app.load_entries(self.app.current_view)
+                self.notify("Entries reloaded")
+        except (ConnectionError, TimeoutError) as e:
+            self.notify(f"Network error refreshing feeds: {e}", severity="error")
+        except Exception as e:
+            self.notify(f"Error refreshing all feeds: {e}", severity="error")
 
     async def action_show_unread(self):
         """Load and show only unread entries."""


### PR DESCRIPTION
## Summary
Implements feed refresh operations for Issue #55, allowing users to refresh all feeds on the server with a single command.

This PR adds:
- **Shift+R keybinding** for refresh all feeds functionality
- **action_refresh_all_feeds()** async method with error handling
- **Clear user notifications** at each step of the refresh process
- **Automatic entry reload** after successful server refresh

## Features

### Keybinding Changes
- 'r' or ',' → Refreshes current view entries (existing, now labeled "Refresh Feed")
- **Shift+R → Refreshes all feeds on server AND reloads entries (new)**

### Implementation
The `action_refresh_all_feeds()` method:
1. Validates API client is available
2. Calls `client.refresh_all_feeds()` to refresh all feeds
3. Provides feedback notifications
4. Automatically reloads entries to display new content
5. Includes error handling for network and generic errors

## User Experience
Clear notifications guide the user through the process:
- "Refreshing all feeds..." - Initial notification
- "All feeds refreshed on server" - Success indication
- "Reloading entries..." - Secondary operation
- "Entries reloaded" - Completion confirmation
- Error messages with severity levels for failures

## Code Quality
- ✅ All 465 tests passing
- ✅ Ruff linting: 0 errors
- ✅ Pyright type checking: 0 errors
- ✅ Pre-commit hooks: passing

## Related Issues
- Implements #55 (Feed operations - refresh all)
- Extends existing refresh functionality with server-side feed refresh
- Foundation for future feed status display

## Architecture
Follows established patterns:
- Async action method using app.client
- Consistent error handling (ConnectionError, TimeoutError, generic Exception)
- User notifications at key points
- Safe, idempotent operation

## Next Steps
- Feed status screen showing problematic feeds (future enhancement)
- Progress indicator for long-running refreshes (future)
- Per-feed refresh statistics (future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)