### PR TITLE
fix: Update OpenSSF Scorecard action to valid version @v2.4.1

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Problem
The OpenSSF Scorecard workflow was failing with:
```
##[error]Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

The issue is that GitHub Actions require specific version tags (e.g., `@v2.4.1`), not major version aliases like `@v2`.

## Solution
Updated the scorecard workflow to use `@v2.4.1`, which is the latest stable release of the OpenSSF Scorecard action.

## Changes
- `.github/workflows/scorecard.yml`: Updated `ossf/scorecard-action@v2` → `@v2.4.1`

## Verification
- ✅ YAML syntax valid
- ✅ Pre-commit hooks passing
- ✅ No other workflow changes needed

## Impact
This fix should resolve all OpenSSF Scorecard workflow failures and allow the security analysis to run properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)