### PR TITLE
fix: Update Renovate SLSA constraint to only allow versions <=2.0.0

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -29,7 +29,7 @@
         {
             "matchDatasources": ["github-tags"],
             "matchPackagePatterns": ["slsa-framework/slsa-github-generator"],
-            "allowedVersions": "!=2.1.0"
+            "allowedVersions": "<=2.0.0"
         }
     ]
 }


### PR DESCRIPTION
## Summary
Changed Renovate SLSA version constraint from `!=2.1.0` to `<=2.0.0` for stricter version locking.

## Changes
- Updated .renovaterc.json to use `allowedVersions: "<=2.0.0"` for SLSA action
- This prevents all versions above 2.0.0 from being used (including v2.1.0 and any future versions)

## Rationale
The stricter constraint ensures we stay on the stable v2.0.0 release and don't inadvertently update to problematic future versions without explicit review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)