### PR TITLE
ci: allow manual zizmor runs

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger to zizmor workflow so we can re-run security scans on demand

## Testing
- n/a (workflow config change only)