### PR TITLE
Fix README logo URL for universal rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # miniflux-tui-py
 
 <div align="center">
-  <img src="assets/logo-256.png" alt="miniflux-tui-py logo" width="128" height="128">
+  <img src="https://raw.githubusercontent.com/reuteras/miniflux-tui-py/main/assets/logo-256.png" alt="miniflux-tui-py logo" width="128" height="128">
 </div>
 
 [![PyPI version](https://badge.fury.io/py/miniflux-tui-py.svg)](https://badge.fury.io/py/miniflux-tui-py)


### PR DESCRIPTION
## Summary
- update the README logo source to use the raw GitHub URL so it renders on GitHub, PyPI, and other sites

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff709f5ca4832eba7e118edee8a06d