### PR TITLE
Fix Scorecard workflow parser issues

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter/slim@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # v7
         env:
-          FILTER_REGEX_EXCLUDE: "(CHANGELOG\.md|CLAUDE\.md)"
+          FILTER_REGEX_EXCLUDE: '(CHANGELOG\.md|CLAUDE\.md)'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_GITLEAKS: false
           VALIDATE_HTML: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: dist/
 
@@ -105,7 +105,7 @@ jobs:
           path: dist/
 
       - name: Generate SLSA provenance
-        uses: slsa-framework/slsa-github-generator@v2.0.0
+        uses: slsa-framework/slsa-github-generator@5a775b367a56d5bd118a224a811bba288150a563 # v2.0.0
         with:
           base64-subjects: ${{ hashFiles('dist/**') }}
           upload-assets: true


### PR DESCRIPTION
## Summary
- Align super-linter regex quoting so the Scorecard parser stops flagging the workflow
- Pin GH Actions in publish flow to immutable commit SHAs

## Testing
- not run