### PR TITLE
Fix formatting for utils tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -238,9 +238,7 @@ class TestGetAppVersion:
 
         assert utils.get_app_version() == expected_version
 
-    def test_get_app_version_recovers_from_metadata_error_with_other_candidates(
-        self, monkeypatch
-    ):
+    def test_get_app_version_recovers_from_metadata_error_with_other_candidates(self, monkeypatch):
         """Continue trying alternative distributions after metadata errors."""
 
         calls = []


### PR DESCRIPTION
## Summary
- reformat `tests/test_utils.py` so it passes the Ruff formatter check

## Testing
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright

------
https://chatgpt.com/codex/tasks/task_e_69003f5220f8832ebe03823aac540406