### PR TITLE
fix: remove trailing blank lines from checklists

### DIFF
--- a/GITHUB_ISSUE_MANUAL_TESTING.md
+++ b/GITHUB_ISSUE_MANUAL_TESTING.md
@@ -222,4 +222,3 @@ For each release, copy this template and fill it out:
 ---
 
 **This issue should remain open** to track testing across all releases. Add new test results as comments for each version.
-

--- a/PRE_RELEASE_TEST_CHECKLIST.md
+++ b/PRE_RELEASE_TEST_CHECKLIST.md
@@ -254,4 +254,3 @@ Maintainer: ______________________ Date: __________
 - ✅ **Critical**: Must pass for release
 - ⚠️ **Major**: Should pass for release
 - ℹ️ **Optional**: Good to verify but not blocking
-


### PR DESCRIPTION
## Summary
- remove trailing blank lines so end-of-file-fixer stays clean

## Testing
- uv run pre-commit run end-of-file-fixer --all-files