### PR TITLE
fix: Address CodeQL security alerts for token permissions

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -7,11 +7,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary

Fixes CodeQL security alert #102 by implementing principle of least privilege for GitHub Actions token permissions.

## Problem

CodeQL flagged `.github/workflows/pre-commit-autoupdate.yml` for having overly permissive token permissions:

```yaml
# BEFORE (Insecure)
permissions:
  contents: write  # Top-level write permission!
```

This grants write access to all jobs by default, which violates security best practices.

## Solution

Implemented principle of least privilege:

```yaml
# AFTER (Secure)
permissions:
  contents: read  # Restrictive by default

jobs:
  autoupdate:
    permissions:
      contents: write  # Write only where needed
```

## Benefits

✅ **Reduced attack surface** - Most jobs run with read-only permissions
✅ **Principle of least privilege** - Write access only where explicitly needed
✅ **OpenSSF Scorecard compliance** - Addresses Token-Permissions check
✅ **Defense in depth** - Limits damage if workflow is compromised

## Cyclic Import Alerts (Not Addressed)

**Note**: CodeQL also reports cyclic import alerts (#105, #104) between `status.py` and `app.py`. These are **false positives**:

- Code uses `TYPE_CHECKING` guard to prevent runtime imports
- Type annotations are quoted (forward references)
- This is the recommended Python pattern for avoiding circular imports
- No actual runtime cyclic dependency exists

**Recommendation**: Dismiss those alerts as false positives in GitHub Security tab.

## Testing

- ✅ Workflow syntax valid
- ✅ No functional changes to workflow behavior
- ✅ Permissions remain sufficient for intended operations

## References

- [GitHub: Workflow permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- [OpenSSF Scorecard: Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)