### PR TITLE
fix: Correct release title and add GitHub attestations

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,8 +60,6 @@ categories:
 
 # Template for the release notes
 template: |
-  # $RELEASE_TITLE
-
   ## Overview
   Exciting new features, improved test coverage, and better code quality.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: dist/
+          attestations: true
 
   release:
     needs: build
@@ -103,6 +104,11 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      - name: Generate GitHub attestations
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.0.0
+        with:
+          subject-path: 'dist/*'
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2


### PR DESCRIPTION
## Summary

Fixes two issues discovered in v0.4.6 release:
1. Release title showing literal "$RELEASE_TITLE" instead of actual title
2. Missing GitHub attestations

## Problem 1: Release Title Template

**Current behavior**: Release shows "$RELEASE_TITLE" as the heading
**Root cause**: Invalid variable in release-drafter template

```yaml
# BEFORE
template: |
  # $RELEASE_TITLE  # ❌ Not a valid variable
```

**Fix**: Remove the invalid variable, let GitHub use the release name as title

```yaml
# AFTER
template: |
  ## Overview  # ✅ No title variable needed
```

## Problem 2: Missing Attestations

There are **TWO types** of attestations:

### PyPI Attestations
- **Where**: Displayed on PyPI.org package page
- **How**: Add `attestations: true` to PyPI publish action
- **Status**: Was in PR #124 but got removed somehow

### GitHub Attestations  
- **Where**: Displayed at github.com/owner/repo/attestations
- **How**: Use `actions/attest-build-provenance` action
- **Status**: Never implemented

## Changes

### 1. Fix Release-Drafter Template

```yaml
# .github/release-drafter.yml
- # $RELEASE_TITLE
+ ## Overview  # Let GitHub use release name
```

### 2. Restore PyPI Attestations

```yaml
# .github/workflows/publish.yml - publish job
- name: Publish to PyPI
  uses: pypa/gh-action-pypi-publish@release/v1
  with:
    packages-dir: dist/
    attestations: true  # ← Re-add this
```

### 3. Add GitHub Attestations

```yaml
# .github/workflows/publish.yml - release job
- name: Generate GitHub attestations
  uses: actions/attest-build-provenance@v2.0.0
  with:
    subject-path: 'dist/*'
```

## Benefits

✅ **Clean release titles** - No more "$RELEASE_TITLE" literal
✅ **PyPI attestations** - Visible on https://pypi.org/project/miniflux-tui-py/
✅ **GitHub attestations** - Visible at /attestations endpoint
✅ **Complete provenance** - Cryptographic proof for both distribution channels

## Testing

This will be validated on the next release:
- Release title should display correctly
- PyPI should show attestations badge
- GitHub /attestations endpoint should work

## References

- [PyPI Attestations](https://docs.pypi.org/attestations/)
- [GitHub Attestations](https://github.blog/security/supply-chain-security/introducing-artifact-attestations-now-in-public-beta/)
- [Release Drafter Variables](https://github.com/release-drafter/release-drafter#template-variables)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)