### PR TITLE
fix: Add attestations:write permission for GitHub attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,6 +88,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1


### PR DESCRIPTION
## Summary

Fixes GitHub attestations failure in v0.4.7 release by adding the required `attestations: write` permission.

## Problem

The v0.4.7 release workflow failed with:
```
Error: Failed to persist attestation: Resource not accessible by integration
```

**Root cause**: `actions/attest-build-provenance@v2` requires `attestations: write` permission to create attestations, but the release job was missing this permission.

## Changes

```yaml
# .github/workflows/publish.yml - release job
permissions:
  contents: write
  id-token: write
  attestations: write  # ← Added
```

## Verification

Current status of v0.4.7:
- ✅ PyPI publish succeeded (https://pypi.org/project/miniflux-tui-py/0.4.7/)
- ✅ PyPI attestations working
- ✅ Release manually published (was draft due to job failure)
- ✅ Release title fixed (no more $RELEASE_TITLE)
- ❌ GitHub attestations failed (this PR fixes it)

Next release will have GitHub attestations at `/attestations` endpoint.

## Testing

This will be validated in the next release (v0.4.8):
- GitHub attestations should succeed
- Release should publish automatically  
- Attestations visible at https://github.com/reuteras/miniflux-tui-py/attestations

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)