### PR TITLE
chore: sync uv lock after 0.4.9 release

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "miniflux-tui-py"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "html2text" },


### PR DESCRIPTION
## Summary
- update `uv.lock` so CI agrees with the 0.4.9 metadata in `pyproject.toml`
- keeps the release workflow change intact: `uv sync --locked` will now pass

## Testing
- uv run pytest
