### PR TITLE
chore: sync uv lock after 0.4.11

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "miniflux-tui-py"
-version = "0.4.9"
+version = "0.4.11"
 source = { editable = "." }
 dependencies = [
     { name = "html2text" },


### PR DESCRIPTION
## Summary
- regenerate `uv.lock` so it reflects the released version 0.4.11
- keeps CI's `uv sync --locked` step green after the release

## Testing
- uv run pytest
