### PR TITLE
Fix editorconfig validation failure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,11 +17,6 @@ insert_final_newline = true
 # Remove any whitespace characters preceding newline characters
 trim_trailing_whitespace = true
 
-# Give operators breathing room, but not brackets
-spaces_around_operators = true
-spaces_around_brackets = true
-space_redirects = true
-
 # Max line length (not supported by all editors)
 # Enable this option by un-commenting the following line
 # max_line_length = 150


### PR DESCRIPTION
## Summary
- remove unsupported EditorConfig properties so the super-linter job passes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6900bfd4bea8832ead4ba04d48939b84