### PR TITLE
Fix changelog unreleased section placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+-
+
+### Changed
+-
+
+### Fixed
+-
+
+
 ## [0.4.11] - 2025-10-28
 
 ### Added
@@ -27,8 +39,6 @@
 ### Bug Fixes
 - Add attestations:write permission for GitHub attestations
 
-
-## [Unreleased]
 
 ## [0.4.7] - 2025-10-28
 


### PR DESCRIPTION
## Summary
- restore the missing Unreleased heading at the top of the changelog
- ensure the placeholder change categories remain under the Unreleased section and remove the duplicate heading farther down the file

## Testing
- uv run pytest tests/test_config.py -q

------
https://chatgpt.com/codex/tasks/task_e_6900d79325e8832e917c02e1538bc566