### PR TITLE
Fix docs workflow dependency sync failure

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-groups --locked
+        run: uv sync --group docs --locked
 
       - name: Build documentation
         run: uv run mkdocs build


### PR DESCRIPTION
## Summary
- stop the docs deployment workflow from installing every dependency group
- only sync the documentation extras so clang-dependent fuzz packages are skipped

## Testing
- uv run pytest tests
- uv run pyright
- uv run ruff check .
- uv run pytest tests --cov=miniflux_tui --cov-report=xml --cov-report=term-missing
- uv sync --group docs --locked
- uv run mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_6900fbbb3710832ea489bf79a1d2e41f