### PR TITLE
ci: install clang for CIFuzz workflow

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Clang toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y clang llvm
+
       - name: Build Fuzzers
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- install the clang and llvm packages before building fuzzers in the CIFuzz workflow
- ensure the atheris dependency can compile its libFuzzer bindings during CI runs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_69011b0274ac832ea8f4854da36b6980