### PR TITLE
Update CIFuzz workflow action pins

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -12,10 +12,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.11"
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload Crash Artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: fuzz-artifacts
           path: fuzz/artifacts


### PR DESCRIPTION
## Summary
- pin the CIFuzz workflow to the latest secure commits for checkout, setup-python, and upload-artifact to clear GitHub security alerts

## Testing
- uv run ruff check miniflux_tui tests
- uv run pyright miniflux_tui tests
- uv run pytest tests --cov=miniflux_tui --cov-report=xml --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_6901237c5184832ea88a5f20854a137b