### PR TITLE
Run OSV scanner nightly

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -7,6 +7,8 @@ on:
   # i.e. "master"
   push:
     branches: [main]
+  schedule:
+    - cron: "0 4 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add a daily 04:00 UTC cron trigger to the OSV scanner workflow so it runs even without pushes

## Testing
- pre-commit (auto via commit)