### PR TITLE
Generate CycloneDX and SPDX SBOMs in CI

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -88,6 +88,32 @@ jobs:
           build-args: |
             PYTHON_VERSION=3.13.3
 
+      - name: Install Syft
+        if: github.event_name != 'pull_request'
+        run: |
+          SYFT_VERSION=v1.19.1
+          curl -sSfL "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin syft
+
+      - name: Generate SBOMs for container image
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p sbom
+          IMAGE="${REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}"
+          SAFE_DIGEST="${IMAGE_DIGEST/:/-}"
+          syft "${IMAGE}" -o cyclonedx-json --file "sbom/miniflux-tui-image-${SAFE_DIGEST}.cdx.json"
+          syft "${IMAGE}" -o spdx-json --file "sbom/miniflux-tui-image-${SAFE_DIGEST}.spdx.json"
+
+      - name: Upload SBOM artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: sbom-container
+          path: sbom/
+          retention-days: 7
+
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,6 +159,30 @@ jobs:
           merge-multiple: true
           path: binaries/
 
+      - name: Install Syft
+        if: github.event_name != 'pull_request'
+        run: |
+          SYFT_VERSION=v1.19.1
+          curl -sSfL "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin syft
+
+      - name: Generate SBOMs for release artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p sbom
+          syft dir:dist -o cyclonedx-json --file sbom/miniflux-tui-pypi.cdx.json
+          syft dir:dist -o spdx-json --file sbom/miniflux-tui-pypi.spdx.json
+          syft dir:binaries -o cyclonedx-json --file sbom/miniflux-tui-binaries.cdx.json
+          syft dir:binaries -o spdx-json --file sbom/miniflux-tui-binaries.spdx.json
+
+      - name: Upload SBOM artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: sbom
+          path: sbom/
+          retention-days: 7
+
       - name: Generate GitHub attestations
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.0.0
         with:
@@ -174,5 +198,6 @@ jobs:
           files: |
             dist/**
             binaries/*
+            sbom/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PRE_RELEASE_TEST_CHECKLIST.md
+++ b/PRE_RELEASE_TEST_CHECKLIST.md
@@ -118,6 +118,10 @@ Test on each target platform:
 - [ ] Run the container with a mounted config directory and verify the TUI launches successfully
 - [ ] (Optional) Verify the signature: `cosign verify ghcr.io/reuteras/miniflux-tui:TAG`
 
+## Supply Chain Artifacts
+
+- [ ] Confirm the release contains SBOM files for PyPI distributions, standalone binaries, and the container image in both CycloneDX and SPDX formats
+
 ## Prebuilt Binaries (if publishing)
 
 - [ ] Linux archive (`miniflux-tui-linux-amd64.tar.gz`) extracts and `./miniflux-tui --check-config` runs

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,6 +42,7 @@ The release script handles:
 - Builds standalone binaries for Linux/macOS/Windows
 - Publishes to PyPI
 - Creates GitHub Release with artifacts
+- Generates CycloneDX and SPDX SBOMs for PyPI artifacts, OS binaries, and container images
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- install syft in release workflows to create CycloneDX and SPDX SBOMs for PyPI dists and platform binaries
- emit matching SBOMs for the container image using the pushed digest
- surface SBOM expectations in the release checklist and attach the files to GitHub Releases

## Testing
- pre-commit (auto via commit)