### PR TITLE
Document PyPI publish action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: dist/
           attestations: true


### PR DESCRIPTION
## Summary
- update the workflow comment to note that the pinned gh-action-pypi-publish digest corresponds to v1.13.0

## Testing
- pre-commit (auto via commit)