### PR TITLE
Potential fix for code scanning alert no. 104: Module-level cyclic import

### DIFF
--- a/miniflux_tui/ui/app.py
+++ b/miniflux_tui/ui/app.py
@@ -14,7 +14,7 @@ from miniflux_tui.constants import DEFAULT_ENTRY_LIMIT
 
 from .screens.entry_list import EntryListScreen
 from .screens.help import HelpScreen
-from .screens.status import StatusScreen
+
 
 if TYPE_CHECKING:
     from miniflux_tui.ui.screens import entry_reader as entry_reader_types


### PR DESCRIPTION
Potential fix for [https://github.com/reuteras/miniflux-tui-py/security/code-scanning/104](https://github.com/reuteras/miniflux-tui-py/security/code-scanning/104)

The standard and safest way to break module-level cyclic imports in Python is to move the problematic import into a local (function/method) scope, ensuring the import only happens when actually needed (after both modules are fully initialized), rather than during module loading. Here, since `StatusScreen` is only used in specific parts of the code (for example, constructing a screen or similar), you should move the `from .screens.status import StatusScreen` import inside the method(s) or function(s) that actually use `StatusScreen`. If it's needed in the class, move it to the methods; if it's used across several methods, consider importing it once in `__init__` or in a helper method.

For this file, in `miniflux_tui/ui/app.py`, identify where `StatusScreen` is used (such as in functions/classes that launch screens) and move the import for `StatusScreen` into those functions/methods, removing the module-level import. This will break the initialization cycle and make the import only occur at runtime, after all modules are loaded.

#### Steps:
1. Remove the line `from .screens.status import StatusScreen` from the global/module level.
2. For each place where `StatusScreen` is used (e.g., instantiated, type hinted, or referenced), add `from .screens.status import StatusScreen` locally inside the function/method before it is needed.
3. No changes to external dependencies or adding new modules are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
