### PR TITLE
Potential fix for code scanning alert no. 126: Empty except

### DIFF
--- a/fuzz/fuzz_config.py
+++ b/fuzz/fuzz_config.py
@@ -23,6 +23,7 @@ def _cleanup_temp_file(path: Path | None) -> None:
     try:
         path.unlink()
     except FileNotFoundError:
+        # The file did not exist; cleanup is already complete.
         pass
     except OSError:
         # The file might already have been removed by the OS or another


### PR DESCRIPTION
Potential fix for [https://github.com/reuteras/miniflux-tui-py/security/code-scanning/126](https://github.com/reuteras/miniflux-tui-py/security/code-scanning/126)

To fix the issue, supply a clear explanatory comment for the empty `except FileNotFoundError:` block in the function `_cleanup_temp_file`. This should explain why it is safe to ignore `FileNotFoundError` in this context, for the benefit of future maintainers and tooling. No functional changes to the code are required; just add a comment explaining the rationale, akin to the comment present in the subsequent `except OSError:` block. Only make changes within the region shown from fuzz/fuzz_config.py.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
