### PR TITLE
ci: limit workflows to relevant paths

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,6 +2,11 @@ name: CIFuzz
 
 on:
   pull_request:
+    paths:
+      - 'miniflux_tui/**'
+      - 'fuzz/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,8 +4,22 @@ name: CodeQL Analysis
 on:
   push:
     branches: [main]
+    paths:
+      - 'miniflux_tui/**'
+      - 'tests/**'
+      - 'fuzz/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'miniflux_tui/**'
+      - 'tests/**'
+      - 'fuzz/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/**'
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,13 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'fuzz/**'
+      - '.github/workflows/dependency-review.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,8 +8,22 @@ name: Code Quality Checks
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'assets/**'
+      - 'config.toml.example'
+      - 'mkdocs.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.md'
+      - '.github/**'
+      - 'docs/**'
+      - 'assets/**'
+      - 'config.toml.example'
+      - 'mkdocs.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -7,6 +7,11 @@ on:
   # i.e. "master"
   push:
     branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'fuzz/**'
+      - '.github/workflows/osv-scanner.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,8 +5,22 @@ on:
   branch_protection_rule:
   push:
     branches: [main]
+    paths:
+      - 'miniflux_tui/**'
+      - 'tests/**'
+      - 'fuzz/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'miniflux_tui/**'
+      - 'tests/**'
+      - 'fuzz/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/**'
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,21 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'mkdocs.yml'
+      - 'config.toml.example'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'mkdocs.yml'
+      - 'config.toml.example'
 
 permissions:
   contents: read

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,8 +4,12 @@ name: GitHub Actions Security Analysis with zizmor
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- scope the Super-Linter workflow to documentation, assets, and workflow updates
- skip test matrix runs on documentation-only changes
- restrict security and fuzzing workflows to dependency, code, and workflow updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901bcb5343c832e916e53b456ce1b7e