### PR TITLE
Stabilize security workflows

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -54,18 +54,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha
+      - name: Compute image tags
+        id: image-tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          tags="${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
+
+          if [[ "${GITHUB_REF}" == "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
+            tags+=$'\n'"${REGISTRY}/${IMAGE_NAME}:latest"
+          fi
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            ref_name="${GITHUB_REF#refs/tags/}"
+            tags+=$'\n'"${REGISTRY}/${IMAGE_NAME}:${ref_name}"
+          elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
+            branch="${GITHUB_REF#refs/heads/}"
+            branch=${branch//\//-}
+            tags+=$'\n'"${REGISTRY}/${IMAGE_NAME}:${branch}"
+          fi
+
+          {
+            echo "tags<<'EOF'"
+            printf '%s\n' "$tags"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
@@ -85,7 +98,7 @@ jobs:
           provenance: true
           sbom: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.image-tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Install Syft

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -58,7 +58,6 @@ jobs:
         env:
           FILTER_REGEX_EXCLUDE: '(CHANGELOG\.md|CLAUDE\.md)'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_GITLEAKS: true
           VALIDATE_HTML: false
           VALIDATE_HTML_PRETTIER: false
           VALIDATE_JSCPD: false
@@ -100,3 +99,25 @@ jobs:
 
       - name: Run Bandit security checks
         run: uv run bandit -q -r miniflux_tui
+
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@e4cf32429aa43056f1a0be423ffa3af658879b26 # v2.3.4
+        with:
+          args: detect --no-git --redact


### PR DESCRIPTION
## Summary
- add a dedicated gitleaks job and restore super-linter configuration so configuration validation passes again
- switch container image tagging to a local script to avoid metadata API rate limits and keep the Trivy scan step running

## Testing
- .venv/bin/ruff check