### PR TITLE
ci: fix gitleaks and zizmor regressions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run gitleaks
         id: gitleaks
         continue-on-error: true
-        uses: gitleaks/gitleaks-action@e4cf32429aa43056f1a0be423ffa3af658879b26 # v2.3.4
+        uses: gitleaks/gitleaks-action@e6dab246340401bf53eec993b8f05aebe80ac636 # v2.3.4
         with:
           args: >-
             detect --no-git --redact --report-format sarif --report-path gitleaks.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -43,9 +43,11 @@ jobs:
       - name: Run zizmor security analysis
         uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
         with:
-          # Enable online audits for comprehensive checks
-          online-audits: true
+          # Disable online audits to avoid cross-repo API calls with limited token scope
+          online-audits: false
           # Use regular persona (not pedantic)
           persona: regular
           # Colorize output for better readability
           color: true
+          # Explicit token for GitHub API access
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- pin gitleaks action to the correct commit for v2.3.4
- disable zizmor online audits and use the GitHub token explicitly to avoid 403s

## Testing
- not run