### PR TITLE
Fix release asset upload to ensure SBOMs are published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -229,6 +229,7 @@ jobs:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          # shellcheck shell=bash
           set -euo pipefail
 
           TAG="${RELEASE_TAG:?RELEASE_TAG environment variable is required}"


### PR DESCRIPTION
## Summary
- replace the softprops release step with a GitHub CLI script that can update existing releases
- fail fast when expected artifact directories are missing and list assets before uploading
- allow uploading to succeed even when the release already exists, ensuring SBOM files are attached

## Testing
- no tests were run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_6902df2e3d30832eb32b8ebc1f58dab5