### PR TITLE
fix(ci): restore syft v1.36.0 flags

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -106,7 +106,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
-          SYFT_VERSION=v1.46.1
+          SYFT_VERSION=v1.36.0
           SYFT_BASE_URL="https://github.com/anchore/syft/releases/download/${SYFT_VERSION}"
           SYFT_ARCHIVE="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
           TMP_DIR="$(mktemp -d)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,7 +180,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
-          SYFT_VERSION=v1.46.1
+          SYFT_VERSION=v1.36.0
           SYFT_BASE_URL="https://github.com/anchore/syft/releases/download/${SYFT_VERSION}"
           SYFT_ARCHIVE="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
           TMP_DIR="$(mktemp -d)"
@@ -200,11 +200,11 @@ jobs:
           mkdir -p sbom
           TAG_NAME="${RELEASE_TAG}"
           VERSION="${TAG_NAME#v}"
-          syft dir:dist --source-name miniflux-tui-py --source-version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-pypi.cdx.json
-          syft dir:dist --source-name miniflux-tui-py --source-version "${VERSION}" --output spdx-json=sbom/miniflux-tui-pypi.spdx.json
+          syft dir:dist --name miniflux-tui-py --version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-pypi.cdx.json
+          syft dir:dist --name miniflux-tui-py --version "${VERSION}" --output spdx-json=sbom/miniflux-tui-pypi.spdx.json
           if compgen -G "binaries/*" > /dev/null; then
-            syft dir:binaries --source-name miniflux-tui --source-version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-binaries.cdx.json
-            syft dir:binaries --source-name miniflux-tui --source-version "${VERSION}" --output spdx-json=sbom/miniflux-tui-binaries.spdx.json
+            syft dir:binaries --name miniflux-tui --version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-binaries.cdx.json
+            syft dir:binaries --name miniflux-tui --version "${VERSION}" --output spdx-json=sbom/miniflux-tui-binaries.spdx.json
           else
             echo "No binary artifacts found; skipping binary SBOM generation."
           fi


### PR DESCRIPTION
## Summary
- revert the publish and container-image workflows to syft v1.36.0
- switch back to the supported --name/--version flags for SBOM generation