### PR TITLE
fix(ci): use correct syft flags --source-name and --source-version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,11 +200,11 @@ jobs:
           mkdir -p sbom
           TAG_NAME="${RELEASE_TAG}"
           VERSION="${TAG_NAME#v}"
-          syft dir:dist --name miniflux-tui-py --version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-pypi.cdx.json
-          syft dir:dist --name miniflux-tui-py --version "${VERSION}" --output spdx-json=sbom/miniflux-tui-pypi.spdx.json
+          syft dir:dist --source-name miniflux-tui-py --source-version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-pypi.cdx.json
+          syft dir:dist --source-name miniflux-tui-py --source-version "${VERSION}" --output spdx-json=sbom/miniflux-tui-pypi.spdx.json
           if compgen -G "binaries/*" > /dev/null; then
-            syft dir:binaries --name miniflux-tui --version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-binaries.cdx.json
-            syft dir:binaries --name miniflux-tui --version "${VERSION}" --output spdx-json=sbom/miniflux-tui-binaries.spdx.json
+            syft dir:binaries --source-name miniflux-tui --source-version "${VERSION}" --output cyclonedx-json=sbom/miniflux-tui-binaries.cdx.json
+            syft dir:binaries --source-name miniflux-tui --source-version "${VERSION}" --output spdx-json=sbom/miniflux-tui-binaries.spdx.json
           else
             echo "No binary artifacts found; skipping binary SBOM generation."
           fi


### PR DESCRIPTION
The previous fix (e822dbe) correctly reverted to syft v1.36.0 but also reverted to incorrect flags (--name and --version).

According to syft documentation, the correct flags are:
- --source-name: set the name of the target being analyzed
- --source-version: set the version of the target being analyzed

This commit fixes the flags while keeping syft at v1.36.0 (latest).

## Changes
- Changed --name to --source-name in publish.yml
- Changed --version to --source-version in publish.yml
- Kept syft version at v1.36.0 (latest available)

## References
- syft issue #1399: Add --version param for Syft
- syft issue #3303: --source-version flag usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)