### PR TITLE
feat: Add Python 3.15 preview support declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 </div>
 
 [![PyPI version](https://img.shields.io/pypi/v/miniflux-tui-py.svg)](https://pypi.org/project/miniflux-tui-py/)
-[![Python 3.11+ | 3.12 | 3.13 | 3.14](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/miniflux-tui-py/)
+[![Python 3.11+ | 3.12 | 3.13 | 3.14 | 3.15](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14%20%7C%203.15-blue)](https://pypi.org/project/miniflux-tui-py/)
 [![Downloads](https://static.pepy.tech/badge/miniflux-tui-py/month)](https://pepy.tech/project/miniflux-tui-py)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Test Status](https://github.com/reuteras/miniflux-tui-py/workflows/Test/badge.svg)](https://github.com/reuteras/miniflux-tui-py/actions/workflows/test.yml)
+[![Python 3.15 Preview](https://img.shields.io/badge/Python%203.15-preview-yellow)](https://github.com/reuteras/miniflux-tui-py/actions/workflows/test.yml)
 [![CIFuzz](https://github.com/reuteras/miniflux-tui-py/actions/workflows/cifuzz.yml/badge.svg)](https://github.com/reuteras/miniflux-tui-py/actions/workflows/cifuzz.yml)
 [![OSV Scanner](https://github.com/reuteras/miniflux-tui-py/actions/workflows/osv-scanner.yml/badge.svg)](https://github.com/reuteras/miniflux-tui-py/actions/workflows/osv-scanner.yml)
 [![CodeQL](https://github.com/reuteras/miniflux-tui-py/actions/workflows/codeql.yml/badge.svg)](https://github.com/reuteras/miniflux-tui-py/actions/workflows/codeql.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",


### PR DESCRIPTION
## Summary
- Added Python 3.15 to project classifiers in pyproject.toml
- Updated Python version badge in README to include 3.15
- Added separate 'Python 3.15 Preview' badge to indicate experimental testing

## Details
The project already tests Python 3.15 via the `test-future` job in test.yml, which runs with `continue-on-error: true` to ensure:
- We catch compatibility issues early (before Oct 2026 release)
- Build doesn't fail on pre-release versions
- Community knows we're forward-compatible

This change formally declares support and visibility for this experimental testing.

## Test plan
- ✅ Existing tests continue to pass
- ✅ Python 3.15 preview tests remain optional (continue-on-error)
- ✅ README accurately reflects supported versions
- ✅ PyPI will show Python 3.15 in classifier metadata

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)