### PR TITLE
fix: Remove configurationFile parameter from Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v43.0.19
         with:
-          configurationFile: .renovaterc.json
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           LOG_LEVEL: 'debug'


### PR DESCRIPTION
## Summary
Removes the `configurationFile` parameter from the Renovate GitHub Action workflow. This parameter was preventing Renovate from detecting the current repository.

## Changes
- Removed `configurationFile: .renovaterc.json` from the workflow step
- Renovate will now automatically discover and use the local `.renovaterc.json` file
- The action will process the repository in its own context without needing explicit repository configuration

## Why This Matters
When `configurationFile` is specified, Renovate expects the configuration to contain a `repositories` list, which is only needed for multi-repo automation. Since this is a local workflow running in the repository's own context, we should let Renovate auto-discover the repository using its default behavior.

## Testing
- Workflow runs successfully
- Renovate now properly detects the repository
- Ready to generate dependency update PRs

## Related Issues
Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)