### PR TITLE
fix: Add RENOVATE_REPOSITORIES to specify target repository

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v43.0.19
         with:
+          configurationFile: .renovaterc.json
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           LOG_LEVEL: 'debug'
-          RENOVATE_CONFIG_FILE: '.renovaterc.json'
+          RENOVATE_REPOSITORIES: 'reuteras/miniflux-tui-py'


### PR DESCRIPTION
## Summary
Explicitly specify the repository Renovate should process using the RENOVATE_REPOSITORIES environment variable.

## Problem
Even with configurationFile set, Renovate wasn't detecting which repository to process when using a configuration file in multi-repo mode.

## Solution
Set `RENOVATE_REPOSITORIES: 'reuteras/miniflux-tui-py'` to explicitly tell Renovate which repository to process. This ensures:
- Renovate finds the configuration file
- Renovate knows which repository to scan
- Dependency updates will be properly detected and PRs created

## Testing
After merge, workflow will run and should create PRs for dependency updates including GitHub Actions hash updates.

## Related Issues
Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)