### PR TITLE
fix: Add vulnerability alerts permission and configuration to Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      workflows: write
+      security-events: read
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,6 +8,9 @@
     "npm": {
         "enabled": false
     },
+    "vulnerabilityAlerts": {
+        "enabled": true
+    },
     "packageRules": [
         {
             "description": "Disable npm updates (not used in this project)",
@@ -49,6 +52,11 @@
             "matchDatasources": ["github-tags"],
             "allowedVersions": "<=2.0.0",
             "matchPackageNames": ["/slsa-framework/slsa-github-generator/"]
+        },
+        {
+            "description": "Skip trivy-action updates due to lookup failures",
+            "matchPackageNames": ["aquasecurity/trivy-action"],
+            "enabled": false
         }
     ]
 }


### PR DESCRIPTION
## Summary

This PR fixes Renovate dashboard warnings and errors reported in issue #268 by adding proper permissions and configuration for vulnerability alert handling.

## Changes

### 1. Renovate Workflow Permissions (`.github/workflows/renovate.yml`)
- **Added**: `security-events: read` - Allows Renovate to access vulnerability alerts and detect vulnerable dependencies
- **Removed**: Invalid `workflows: write` permission (not a valid GitHub Actions permission scope)

### 2. Renovate Configuration (`.renovaterc.json`)
- **Enabled**: `vulnerabilityAlerts` - Explicitly enable vulnerability alert detection
- **Added Rule**: Disable `aquasecurity/trivy-action` updates to prevent recurring lookup failures

## Problems Fixed

1. ✅ **WARN: Cannot access vulnerability alerts** → Fixed by adding `security-events: read` permission
2. ✅ **WARN: Package lookup failures** (trivy-action) → Fixed by disabling problematic package
3. ✅ **WARN: Invalid workflows permission** → Fixed by replacing with valid `security-events: read`

## Impact

- Renovate can now detect vulnerable dependencies in security alerts
- Eliminates confusing lookup failure errors in Renovate dashboard
- Cleans up remaining invalid GitHub Actions permissions
- Enables proper security vulnerability patching workflow

## Testing

- Pre-commit hooks: ✅ All passing
- YAML validation: ✅ Valid configuration
- Renovate dashboard: Should show no warnings/errors on next run

## Related Issues

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)