### PR TITLE
fix: Wrap bare URLs in angle brackets for markdown linting compliance

### DIFF
--- a/docs/free-tool-alternatives.md
+++ b/docs/free-tool-alternatives.md
@@ -448,10 +448,10 @@ A: Coverage migration: 1-2 hours. Full stack migration: 1-2 weeks testing everyt
 
 ## Support
 
-- Coveralls: https://coveralls.io
-- MegaLinter: https://megalinter.io
-- Semgrep: https://semgrep.dev
-- GitHub Pages: https://pages.github.com
+- Coveralls: <https://coveralls.io>
+- MegaLinter: <https://megalinter.io>
+- Semgrep: <https://semgrep.dev>
+- GitHub Pages: <https://pages.github.com>
 
 ## Conclusion
 

--- a/docs/quick-reference-free-tools.md
+++ b/docs/quick-reference-free-tools.md
@@ -211,9 +211,9 @@ Everything recommended: **$0 forever**
 
 - **Full Guide:** `docs/free-tool-alternatives.md`
 - **All Recommendations:** `WORKFLOW_IMPROVEMENTS.md`
-- **Coveralls:** https://coveralls.io
-- **MegaLinter:** https://megalinter.io
-- **Semgrep:** https://semgrep.dev
+- **Coveralls:** <https://coveralls.io>
+- **MegaLinter:** <https://megalinter.io>
+- **Semgrep:** <https://semgrep.dev>
 
 ## Support
 


### PR DESCRIPTION
## Summary
Fixed bare URL formatting issues in documentation files that were causing MegaLinter markdown linting failures.

- Fixed 3 bare URLs in `docs/quick-reference-free-tools.md`
- Fixed 4 bare URLs in `docs/free-tool-alternatives.md`
- All URLs now wrapped in angle brackets per CommonMark specification

## Test plan
- [x] Pre-commit hooks passing
- [x] Markdown lint rules compliant (URLs in angle brackets)
- [x] Documentation content unchanged, only formatting fixed

## Blocking Issues
This PR unblocks:
- PR #275 (MegaLinter full codebase validation)
- PR #276 (Actionlint shell variable fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)