### PR TITLE
fix: Remove remaining invalid configuration options from Renovate and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       day: "monday"
       time: "03:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "reuteras"
     pull-request-branch-name:
       separator: "/"
     # Auto-merge minor and patch updates, leave major for manual review
@@ -42,7 +40,5 @@ updates:
       day: "monday"
       time: "03:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "reuteras"
     cooldown:
       default-days: 7

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -14,7 +14,6 @@
     },
     "prConcurrentLimit": 10,
     "ignoreDeps": [],
-    "recreateWhen": "always",
     "groupName": "Renovate Dependency Updates",
     "groupSlug": "dependency-updates",
     "labels": ["dependencies", "renovate"],


### PR DESCRIPTION
## Problem

After PR #299 was partially merged, there are still configuration validation errors in CI:

### Renovate Configuration (.renovaterc.json)
- `recreateWhen: "always"` - Not a valid Renovate option
- v8r validation error: `recreateWhen must be equal to one of the allowed values`

### Dependabot Configuration (.github/dependabot.yml)
- `reviewers` option deprecated as of August 2025
- GitHub recommends using CODEOWNERS file instead
- v8r validation errors: `must NOT have additional properties, found additional property 'reviewers'`

## Solution

**Renovate Config (.renovaterc.json):**
- Remove `recreateWhen: "always"` (line 17)

**Dependabot Config (.github/dependabot.yml):**
- Remove deprecated `reviewers` from pip updates (lines 12-13)
- Remove deprecated `reviewers` from github-actions updates (lines 45-46)

## Impact
- Fixes v8r schema validation failures in CI
- Allows Renovate and Dependabot to function properly
- Resolves Code Quality Checks workflow failures

Fixes #300