### PR TITLE
feat: Add Dependabot PR to Issue tracker workflow

### DIFF
--- a/.github/workflows/dependabot-issue-tracker.yml
+++ b/.github/workflows/dependabot-issue-tracker.yml
@@ -1,0 +1,53 @@
+---
+name: Create Issue for Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  create-issue-for-dependabot:
+    name: Create Tracking Issue
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Create issue for Dependabot PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            const title = `[Dependabot] ${pr.title}`;
+            const prLink = `[PR #${pr.number}](${pr.html_url})`;
+            const body = `Dependabot has opened a pull request for dependency updates.\n\n` +
+              `**Related PR:** ${prLink}\n\n` +
+              `**PR Title:** ${pr.title}\n\n` +
+              `**Dependency Details:**\n${pr.body || 'No additional details provided'}\n\n` +
+              `---\n*This is an automatically generated tracking issue.*`;
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              labels: ['dependencies', 'dependabot']
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `Tracking issue created: #${issue.data.number}`
+            });
+
+            console.log(`Created issue #${issue.data.number} for PR #${pr.number}`);


### PR DESCRIPTION
## Feature

Automatically create tracking issues for every Dependabot pull request. This ensures better visibility and issue management for all dependency updates.

## What This Does

When Dependabot opens a pull request:
1. GitHub Actions workflow automatically triggers
2. Creates a corresponding issue in the repository
3. Links the issue to the PR with a comment
4. Tags issues with 'dependencies' and 'dependabot' labels

## Example

When Dependabot creates a PR titled "chore(deps): Update python to v3.14", a tracking issue will be created with:
- Title: "[Dependabot] chore(deps): Update python to v3.14"
- Links to the PR
- Includes full dependency update details
- Tagged as dependencies/dependabot

## Benefits

- Better issue tracking for all dependency updates
- Easy to reference dependency changes through issues
- Maintains organized issue/PR relationship
- Only affects Dependabot bot (no impact on other PRs)

Related to #268