### PR TITLE
fix: Remove --system flag from pip-licenses installation in license c…

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv sync --locked
 
       - name: Install pip-licenses
-        run: uv pip install --system pip-licenses
+        run: uv pip install pip-licenses
 
       - name: Generate license report
         run: |


### PR DESCRIPTION
…heck

## Problem
The license check workflow was failing because pip-licenses was being installed to system Python with the --system flag, but then being invoked with 'uv run' which looks for the command in the managed uv environment.

## Solution
Remove the --system flag so pip-licenses gets installed in the managed environment where 'uv run' can find it.

## Testing
Verified locally that:
- uv pip install pip-licenses works correctly
- uv run pip-licenses generates the license report successfully
- The license compatibility check runs and properly detects copyleft licenses