### PR TITLE
fix: Restrict auto-merge to verified dependabot[bot] account type

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,9 @@ jobs:
       contents: write  # Required for auto-merge to commit code changes
       pull-requests: write  # Required to approve and merge PRs
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.user.type == 'Bot'
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
Add account type verification to dependabot-auto-merge workflow to ensure only the official dependabot[bot] (type: Bot) can trigger auto-merge.

## Security Impact
- Prevents potential account impersonation by checking both login name AND account type
- Aligns with security practices in auto-approve.yml and dependabot-issue-tracker.yml
- Mitigates risk of unauthorized auto-merge from user accounts

## Changes
- Add 'github.event.pull_request.user.type == Bot' check to workflow condition
- Use multi-line YAML format for better readability