### PR TITLE
chore: Increase dependabot cooldown from 1 to 4 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
           - "miniflux*"
           - "html2text*"
     cooldown:
-      default-days: 1
+      default-days: 4
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -42,11 +42,11 @@ updates:
     open-pull-requests-limit: 5
     pin-versions: true
     cooldown:
-      default-days: 1
+      default-days: 4
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: daily
     cooldown:
-      default-days: 1
+      default-days: 4


### PR DESCRIPTION
## Summary
Increase the cooldown period for dependabot updates from 1 day to 4 days to reduce noise from frequent dependency updates.

## Changes
- Updated `.github/dependabot.yml`:
  - `pip` ecosystem: `default-days: 1` → `default-days: 4`
  - `github-actions` ecosystem: `default-days: 1` → `default-days: 4`
  - `docker` ecosystem: `default-days: 1` → `default-days: 4`

## Rationale
- Reduce frequency of dependency update PRs
- Allow time for upstream issues to be discovered
- Batch related updates that may come in close succession
- Reduce CI/CD resource usage from excessive PR builds

## Impact
- Lower volume of automated PRs (from daily to every 4 days minimum)
- More stable dependency update cadence
- Reduced notification noise
- Better alignment with weekly schedule (Monday runs)

## Testing
- [x] Configuration file syntax validated
- [x] No functional changes to application code
- [x] Change only affects Dependabot PR creation frequency

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)