### PR TITLE
fix: Resolve cyclic import warnings with Protocol-based app interface

### DIFF
--- a/miniflux_tui/ui/app_protocol.py
+++ b/miniflux_tui/ui/app_protocol.py
@@ -1,0 +1,81 @@
+"""Protocol definition for MinifluxTUI app interface.
+
+This module provides a Protocol that defines the interface screens expect from
+the main application, breaking cyclic dependencies between app.py and screen modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from miniflux_tui.api.client import MinifluxClient
+    from miniflux_tui.api.models import Entry
+
+
+@runtime_checkable
+class MinifluxAppProtocol(Protocol):
+    """Protocol defining the interface that screens expect from the app.
+
+    This protocol breaks the cyclic import between app.py and screen modules
+    by defining the expected interface without importing the actual MinifluxTuiApp class.
+    """
+
+    # API client
+    client: MinifluxClient | None
+
+    # Application state
+    current_view: str
+    entry_category_map: dict[int, int]
+
+    # Logging and notifications
+    def log(self, message: str, /) -> None:
+        """Log a message."""
+        ...
+
+    def notify(
+        self,
+        message: str,
+        /,
+        *,
+        title: str = "",
+        severity: str = "information",
+        timeout: float = ...,
+    ) -> None:
+        """Send a notification to the user."""
+        ...
+
+    # Screen navigation
+    def pop_screen(self) -> None:
+        """Pop the current screen from the stack."""
+        ...
+
+    def push_screen(self, screen: str | object, /) -> None:
+        """Push a screen onto the stack."""
+        ...
+
+    def exit(self, return_code: int = 0, /) -> None:
+        """Exit the application."""
+        ...
+
+    # Custom app methods
+    def push_entry_reader(
+        self,
+        entry: Entry,
+        entry_list: list | None = None,
+        current_index: int = 0,
+    ) -> None:
+        """Push entry reader screen for a specific entry."""
+        ...
+
+    async def push_category_management_screen(self) -> None:
+        """Push category management screen."""
+        ...
+
+    async def load_entries(self, view: str = "unread") -> None:
+        """Load entries from Miniflux API."""
+        ...
+
+    async def _build_entry_category_mapping(self) -> dict[int, int]:
+        """Build a mapping of entry_id → category_id."""
+        ...

--- a/miniflux_tui/ui/base_screen.py
+++ b/miniflux_tui/ui/base_screen.py
@@ -7,12 +7,11 @@ All screens inherit from this base to properly type-hint the app property.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from textual.screen import Screen
 
-if TYPE_CHECKING:
-    from miniflux_tui.ui.app import MinifluxTuiApp
+from miniflux_tui.ui.app_protocol import MinifluxAppProtocol
 
 
 class BaseScreen(Screen[Any]):
@@ -25,10 +24,10 @@ class BaseScreen(Screen[Any]):
     """
 
     @property
-    def app(self) -> MinifluxTuiApp:  # type: ignore[override,return-value,reportReturnType]
+    def app(self) -> MinifluxAppProtocol:  # type: ignore[override,return-value,reportReturnType]
         """Get the app instance with proper typing.
 
         Returns:
-            MinifluxTuiApp: The application instance
+            MinifluxAppProtocol: The application instance following the protocol
         """
         return super().app  # type: ignore[return-value]


### PR DESCRIPTION
## Summary
Fix cyclic import warnings detected by GitHub CodeQL by introducing a Protocol-based app interface, following best practices from Rollbar's guide on fixing circular imports.

## Problem
GitHub code scanning identified two cyclic import issues:

### Alert #262: `base_screen.py` ↔ `app.py`
```
'MinifluxTuiApp' may not be defined if module miniflux_tui.ui.app is imported 
before module miniflux_tui.ui.base_screen, as the definition of MinifluxTuiApp 
occurs after the cyclic import of miniflux_tui.ui.base_screen.
```

### Alert #263: `entry_history.py` ↔ `base_screen.py`  
```
'BaseScreen' may not be defined if module miniflux_tui.ui.base_screen is imported 
before module miniflux_tui.ui.screens.entry_history, as the definition of BaseScreen 
occurs after the cyclic import of miniflux_tui.ui.screens.entry_history.
```

### Root Cause
The import cycle was:
1. `app.py` → `entry_history.py` (via TYPE_CHECKING)
2. `entry_history.py` → `base_screen.py` (runtime import)
3. `base_screen.py` → `app.py` (via TYPE_CHECKING)

Even with TYPE_CHECKING guards, CodeQL flagged this as unsafe because import order can still cause initialization issues.

## Solution
Following the **"Refactoring and Code Reorganization"** approach recommended by [Rollbar's guide](https://rollbar.com/blog/how-to-fix-circular-import-in-python/):

1. **Created `miniflux_tui/ui/app_protocol.py`** - Defines `MinifluxAppProtocol` that describes the app interface screens need
2. **Updated `base_screen.py`** - Uses the Protocol instead of importing `MinifluxTuiApp` directly
3. **No changes to screen implementations** - They continue to work as before

### Why This Works
- The Protocol doesn't import from `app.py`, breaking the cycle
- Maintains full type safety through structural subtyping
- `MinifluxTuiApp` implicitly satisfies the Protocol at runtime
- Minimal code changes required

## Changes

### New File: `miniflux_tui/ui/app_protocol.py`
```python
@runtime_checkable
class MinifluxAppProtocol(Protocol):
    """Protocol defining the interface that screens expect from the app."""
    
    # Defines all methods and attributes screens use:
    # - client, current_view, entry_category_map
    # - log(), notify(), pop_screen(), push_screen(), exit()
    # - push_entry_reader(), push_category_management_screen()
    # - load_entries(), _build_entry_category_mapping()
```

### Modified: `miniflux_tui/ui/base_screen.py`
**Before:**
```python
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from miniflux_tui.ui.app import MinifluxTuiApp

class BaseScreen(Screen[Any]):
    @property
    def app(self) -> MinifluxTuiApp:
        return super().app
```

**After:**
```python
from miniflux_tui.ui.app_protocol import MinifluxAppProtocol

class BaseScreen(Screen[Any]):
    @property
    def app(self) -> MinifluxAppProtocol:
        return super().app
```

## Benefits
- ✅ Eliminates cyclic import warnings
- ✅ Improves code architecture (separates interface from implementation)
- ✅ Maintains 100% type safety
- ✅ No runtime behavior changes
- ✅ Follows Python best practices
- ✅ Makes the app interface explicit and documented

## Testing
- ✅ All 739 tests pass
- ✅ Pyright type checking: 0 errors, 0 warnings
- ✅ Ruff linting: All checks pass
- ✅ No runtime changes (existing screens work unchanged)

## Impact
- **Low risk** - Only changes type hints, no runtime logic
- **High value** - Resolves code scanning alerts and improves architecture
- **Future-proof** - Protocol pattern scales well for adding new screens

## References
- Rollbar guide: [How to Fix Circular Import in Python](https://rollbar.com/blog/how-to-fix-circular-import-in-python/)
- Python PEP 544: [Protocols: Structural subtyping](https://peps.python.org/pep-0544/)

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)