### PR TITLE
fix: Exclude CodeQL config from YAML v8r schema validation

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,3 +1,3 @@
 ---
-# Skip schema validation for Dependabot config until upstream schema adds support for pin-versions
-YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i).github/dependabot\\.yml"
+# Skip schema validation for configs without schemas in schemastore.org
+YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i)(\\.github/dependabot\\.yml|\\.github/codeql/codeql-config\\.yml)"


### PR DESCRIPTION
## Summary
Fix the blocking YAML v8r schema validation error in Code Quality Checks workflow by excluding CodeQL config files from schema validation.

## Problem
The Code Quality Checks workflow was failing with a blocking error:

```
❌ Linted [YAML] files with [v8r]: Found 1 error(s)
✖ Could not find a schema to validate .github/codeql/codeql-config.yml
```

**Root Cause:** The v8r linter tries to validate all YAML files against schemas from schemastore.org, but CodeQL config files don't have a published schema there. CodeQL validates its own config files independently.

**Impact:** Blocked the Code Quality Checks workflow from passing.

## Solution
Extended the existing `YAML_V8R_FILTER_REGEX_EXCLUDE` pattern in `.mega-linter.yml` to also exclude CodeQL config files:

**Before:**
```yaml
YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i).github/dependabot\\.yml"
```

**After:**
```yaml
YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i)(\\.github/dependabot\\.yml|\\.github/codeql/codeql-config\\.yml)"
```

This allows v8r to skip schema validation for both:
- Dependabot config (already excluded due to missing schema for `pin-versions`)
- CodeQL config (no schema available in schemastore.org)

## Changes
- **Modified:** `.mega-linter.yml` - Updated v8r exclusion regex

## Testing
- ✅ All 739 tests pass locally
- ✅ YAML syntax is valid
- ✅ CodeQL validates its own config independently
- ✅ No functional changes to application code

## Non-Blocking Warnings (Not Fixed)
This PR addresses only the **blocking error**. The following non-blocking warnings remain:

### ⚠️ JSON Prettier (4 files)
Files need prettier formatting:
- `.devcontainer/devcontainer.json`
- `.renovaterc.json`
- `.vscode/launch.json`
- `.vscode/settings.json`

**Why not fixed:** Requires Node.js tooling (npm/npx) which we avoid. These are warnings only and don't block CI.

### ⚠️ Markdown Table Formatter (10 files)
Markdown tables could be formatted more consistently:
- README.md
- docs/RELEASE_TROUBLESHOOTING.md
- docs/api/screens.md
- And 7 other docs files

**Why not fixed:** `markdown-table-formatter` installation issue via uvx. These are warnings only and don't block CI.

## Impact
- ✅ Unblocks Code Quality Checks workflow
- ✅ No runtime behavior changes
- ✅ No impact on application functionality

## References
- Issue #354 - Code quality and test workflow failures
- Failed workflow run: Code Quality Checks (19024948012)
- CodeQL config is validated by CodeQL itself during the CodeQL Analysis workflow

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)