### PR TITLE
fix: Exclude .yaml-lint.yml from YAML v8r schema validation

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,3 +1,3 @@
 ---
 # Skip schema validation for configs without schemas in schemastore.org
-YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i)(\\.github/dependabot\\.yml|\\.github/codeql/codeql-config\\.yml)"
+YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i)(\\.github/dependabot\\.yml|\\.github/codeql/codeql-config\\.yml|\\.yaml-lint\\.yml)"


### PR DESCRIPTION
## Summary
Fix YAML v8r schema validation error by excluding `.yaml-lint.yml` from validation.

## Problem
After PR #355 fixed the CodeQL config issue, Code Quality Checks is still failing with:
```
❌ Linted [YAML] files with [v8r]: Found 1 error(s)
✖ Could not find a schema to validate .yaml-lint.yml
```

**Root Cause:** The yamllint configuration file doesn't have a schema published in schemastore.org, and v8r tries to validate all YAML files against schemas.

## Solution
Extended the `YAML_V8R_FILTER_REGEX_EXCLUDE` pattern to also exclude `.yaml-lint.yml`:

**Before:**
```yaml
YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i)(\\.github/dependabot\\.yml|\\.github/codeql/codeql-config\\.yml)"
```

**After:**
```yaml
YAML_V8R_FILTER_REGEX_EXCLUDE: "(?i)(\\.github/dependabot\\.yml|\\.github/codeql/codeql-config\\.yml|\\.yaml-lint\\.yml)"
```

Now excludes:
- Dependabot config (no schema for `pin-versions`)
- CodeQL config (no schema available)
- Yamllint config (no schema available)

All three are validated by their respective tools and don't need v8r validation.

## Changes
- **Modified:** `.mega-linter.yml` - Added `.yaml-lint.yml` to v8r exclusion pattern

## Testing
- ✅ YAML syntax is valid
- ✅ Yamllint validates its own config
- ✅ No functional changes

## Impact
- ✅ Unblocks Code Quality Checks workflow
- ✅ No runtime changes

## References
- Issue #356
- PR #355 (fixed CodeQL config issue)
- Failed run: Code Quality Checks (19025610925)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)