### PR TITLE
fix: Remove ellipsis statements from Protocol methods to resolve code scanning alerts

### DIFF
--- a/miniflux_tui/ui/app_protocol.py
+++ b/miniflux_tui/ui/app_protocol.py
@@ -31,7 +31,6 @@ class MinifluxAppProtocol(Protocol):
     # Logging and notifications
     def log(self, message: str, /) -> None:
         """Log a message."""
-        ...
 
     def notify(
         self,
@@ -43,20 +42,16 @@ class MinifluxAppProtocol(Protocol):
         timeout: float = ...,
     ) -> None:
         """Send a notification to the user."""
-        ...
 
     # Screen navigation
     def pop_screen(self) -> None:
         """Pop the current screen from the stack."""
-        ...
 
     def push_screen(self, screen: str | object, /) -> None:
         """Push a screen onto the stack."""
-        ...
 
     def exit(self, return_code: int = 0, /) -> None:
         """Exit the application."""
-        ...
 
     # Custom app methods
     def push_entry_reader(
@@ -66,16 +61,12 @@ class MinifluxAppProtocol(Protocol):
         current_index: int = 0,
     ) -> None:
         """Push entry reader screen for a specific entry."""
-        ...
 
     async def push_category_management_screen(self) -> None:
         """Push category management screen."""
-        ...
 
     async def load_entries(self, view: str = "unread") -> None:
         """Load entries from Miniflux API."""
-        ...
 
     async def _build_entry_category_mapping(self) -> dict[int, int]:
         """Build a mapping of entry_id → category_id."""
-        ...


### PR DESCRIPTION
## Problem
Fixes #358

GitHub code scanning identified 9 'Statement has no effect' alerts in `miniflux_tui/ui/app_protocol.py` (alerts #269-277).

## Root Cause
Protocol method definitions used `...` (ellipsis) statements which CodeQL flags as statements with no effect.

## Solution
Removed all `...` statements from `MinifluxAppProtocol` method definitions. Protocol methods in Python don't require body statements - they can have just the signature and docstring.

## Changes
- Removed ellipsis from 9 protocol method definitions (lines 34, 46, 51, 55, 59, 69, 73, 77, 81)
- All tests pass successfully
- No functional changes - this is purely a code quality improvement

## Testing
- ✅ Full test suite passes (`uv run pytest tests/`)
- ✅ Protocol behavior unchanged (methods still properly define the interface)

This should resolve all 9 code scanning alerts once GitHub rescans the code.