### PR TITLE
fix: Configure VS Code to run pytest via uv in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,10 @@
                 "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
                 "python.testing.pytestEnabled": true,
                 "python.testing.unittestEnabled": false,
+                "python.testing.pytestPath": "uv",
                 "python.testing.pytestArgs": [
+                    "run",
+                    "pytest",
                     "tests"
                 ],
                 "python.testing.cwd": "${workspaceFolder}",


### PR DESCRIPTION
## Problem
Relates to #360

When using Codespaces in the browser, VS Code Python extension fails to discover tests:
```
/workspaces/miniflux-tui-py/.venv/bin/python: No module named pytest
Subprocess exited unsuccessfully with exit code 1
```

## Root Cause
VS Code's Python extension tries to run pytest directly via `.venv/bin/python -m pytest`, but with `uv`, the virtual environment is managed differently and pytest isn't directly accessible in the venv path.

## Solution
Configure VS Code to run pytest through `uv`:
```json
"python.testing.pytestPath": "uv",
"python.testing.pytestArgs": ["run", "pytest", "tests"]
```

This makes VS Code execute: `uv run pytest tests`

## Benefits
✅ Test discovery works in Codespaces browser environment  
✅ Tests run with proper environment management via uv  
✅ All dependencies are correctly available during test execution  
✅ No changes needed to existing test infrastructure

## Testing
After merging, users should:
1. Rebuild Codespace (or reload window)
2. Open VS Code Test Explorer
3. Tests should now be discovered and runnable

## Related
- Issue #360 (Codespaces configuration improvements)