### PR TITLE
fix: Use unique coverage filenames to prevent overwriting during merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
         run: uv run pyright miniflux_tui tests
 
       - name: Run tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.${{ matrix.os }}-py${{ matrix.python-version }}
         run: |
           uv run --with pytest-xdist pytest tests --cov=miniflux_tui --cov-report=xml \
             --cov-report=term-missing --cov-report=html \
@@ -88,7 +90,7 @@ jobs:
           name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
             coverage.xml
-            .coverage
+            .coverage.${{ matrix.os }}-py${{ matrix.python-version }}
           retention-days: 7
 
       - name: Upload coverage to Coveralls
@@ -265,7 +267,8 @@ jobs:
       - name: Combine coverage reports
         run: |
           cd coverage-data
-          uvx coverage combine --keep
+          ls -la  # Debug: show what files we have
+          uvx coverage combine --keep .coverage.*
           uvx coverage xml -o ../coverage.xml
           uvx coverage html --directory=../htmlcov
 


### PR DESCRIPTION
## Problem
Fixes #370

The "Generate Coverage Report" job was failing with:
```
No data to combine
Process completed with exit code 1
```

All Python version tests (3.11-3.15) passed successfully, but the coverage report combination failed.

## Root Cause
When multiple test jobs run in parallel, they all create a `.coverage` file with the same name. The workflow downloads artifacts with `merge-multiple: true`, which flattens all artifacts into one directory. This caused all `.coverage` files to overwrite each other, leaving only one file instead of 12.

## Solution

### 1. Unique coverage filenames
Set `COVERAGE_FILE` environment variable to create unique names:
```yaml
env:
  COVERAGE_FILE: .coverage.${{ matrix.os }}-py${{ matrix.python-version }}
```

### 2. Upload the correct file
Updated upload step to use the unique filename:
```yaml
path: |
  coverage.xml
  .coverage.${{ matrix.os }}-py${{ matrix.python-version }}
```

### 3. Combine all files
Updated combine command to find all coverage files:
```bash
uvx coverage combine --keep .coverage.*
```

## Result
- ✅ Each test job's coverage data is preserved with unique filename
- ✅ All 12 coverage files are available for combining
- ✅ Coverage report generation should now succeed
- ✅ Added debug `ls -la` to verify files in case of future issues

## Testing
Will verify on main branch after merge that the coverage report is generated successfully.