### PR TITLE
chore: Use "explicit" for VS Code code actions format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.codeActionsOnSave": {
-            "source.fixAll.ruff": true,
-            "source.organizeImports.ruff": true
+            "source.fixAll.ruff": "explicit",
+            "source.organizeImports.ruff": "explicit"
         }
     },
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",


### PR DESCRIPTION
## Change
Changed VS Code settings from boolean `true` to string `"explicit"` for code actions:

```json
"source.fixAll.ruff": "explicit",
"source.organizeImports.ruff": "explicit"
```

## Why
- `"explicit"` is the newer recommended format by VS Code
- Prevents VS Code from showing a diff/suggestion on startup
- Functionally equivalent to `true` but follows current VS Code conventions

## Impact
- No functional changes - both formats work identically
- Eliminates the cosmetic diff that appears in Codespaces
- Keeps settings aligned with VS Code best practices