### PR TITLE
fix: Set VALIDATE_ALL_CODEBASE to true in MegaLinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,7 +42,7 @@ jobs:
         id: ml
         uses: oxsecurity/megalinter/flavors/python@62c799d895af9bcbca5eacfebca29d527f125a57 # v9.1.0
         env:
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: '(CHANGELOG\.md|CLAUDE\.md|AGENT\.md|WORKFLOW_IMPROVEMENTS\.md)'
           # Disable linters that overlap with project tools (ruff + pyright) or cause false positives


### PR DESCRIPTION
## Change
Set `VALIDATE_ALL_CODEBASE: true` in MegaLinter workflow to validate all sources, not only the diff.

## Why
Previously, the setting was conditional:
```yaml
VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
```

This meant:
- ❌ PRs only validated changed files
- ✅ Main branch pushes validated all files

Problems with conditional validation:
1. Issues in unchanged files could slip through on PRs
2. Inconsistent validation behavior between PRs and main
3. Could merge code that fails full validation

## Solution
Always validate all code:
```yaml
VALIDATE_ALL_CODEBASE: true
```

## Benefits
- ✅ Consistent validation on PRs and main
- ✅ Catch issues in all files, not just changes
- ✅ More thorough code quality checks
- ✅ Follows MegaLinter best practices

## Note
This may increase CI time slightly, but ensures comprehensive validation.