### PR TITLE
fix: Enable editorconfig-checker in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,11 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
-  # - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-  #   rev: 3.4.1
-  #   hooks:
-  #     - id: editorconfig-checker
-  #       alias: ec
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 3.4.1
+    hooks:
+      - id: editorconfig-checker
+        alias: ec
   - repo: https://github.com/owenlamont/uv-secure
     rev: 0.14.3
     hooks:


### PR DESCRIPTION
## Change
Re-enabled the editorconfig-checker hook that was previously commented out.

## Why Was It Disabled?
Unknown - the  file exists and is well-configured, and all files pass the check.

## Testing
```bash
uv run pre-commit run editorconfig-checker --all-files
```
Result: ✅ **All files pass**

## Benefits
- ✅ Enforces consistent formatting (line endings, indentation, trailing whitespace)
- ✅ Catches formatting issues before commit
- ✅ Complements ruff and other formatters
- ✅ Already configured in `.editorconfig`
- ✅ No issues found in codebase

## Configuration
The checker validates:
- Line endings (LF)
- UTF-8 encoding
- Indentation (4 spaces for Python, 2 for YAML/Markdown)
- Final newline
- Trailing whitespace removal