### PR TITLE
fix: Copy .coverage file for python-coverage-comment-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,10 @@ jobs:
             echo "ℹ️ Target: ≥70% coverage on changed lines"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Copy coverage file for comment action
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        run: cp .coverage.${{ matrix.os }}-py${{ matrix.python-version }} .coverage
+
       - name: Coverage comment on PR
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: py-cov-action/python-coverage-comment-action@e623398c19eb3853a5572d4a516e10b15b5cefbc # v3.39


### PR DESCRIPTION
## Summary
Fixes the pre-existing CI failure in ubuntu-latest / Python 3.13 job.

## Problem
The `python-coverage-comment-action` expects a file named `.coverage` but our workflow creates `.coverage.<os>-py<version>` to avoid conflicts between matrix jobs. This causes the action to fail with "No data to report" error.

## Solution
Copy the matrix-specific coverage file to `.coverage` before running the action on the ubuntu-latest / Python 3.13 job.

## Testing
- Verified locally that .coverage files are generated with the matrix naming scheme
- Action only runs on PR events for ubuntu-latest / Python 3.13

## Related
- Fixes pre-existing failure that was also affecting PR #392
- This issue existed on main branch before our PR #392 fixes