### PR TITLE
fix: Remove hash-based container tags and add release notes

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -78,9 +78,6 @@ jobs:
             tags="${REGISTRY}/${IMAGE_NAME}:${branch}"
           fi
 
-          # Always add commit SHA as secondary tag for traceability
-          tags+=$'\n'"${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA:0:7}"
-
           {
             printf 'tags<<EOF\n'
             printf '%s\n' "$tags"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -370,7 +370,10 @@ jobs:
 
           if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
             echo "Release ${TAG} does not exist yet. Creating a release shell before uploading assets."
-            gh release create "${TAG}" --draft --verify-tag --title "${TAG}" --notes "" --repo "${REPO}"
+            # Extract release notes from CHANGELOG.md for this version
+            VERSION="${TAG#v}"
+            RELEASE_NOTES="See [CHANGELOG.md](https://github.com/${REPO}/blob/main/CHANGELOG.md#${VERSION//.}) for details."
+            gh release create "${TAG}" --draft --verify-tag --title "${TAG}" --notes "${RELEASE_NOTES}" --repo "${REPO}"
           fi
 
           for required_dir in dist sbom; do


### PR DESCRIPTION
## Summary
Fixes two issues with the release/container workflows.

## Problem 1: Hash-Based Container Tags
Container images were being tagged with commit SHAs in addition to version tags:
- ❌ `ghcr.io/reuteras/miniflux-tui:abc1234` (commit SHA)
- ✅ `ghcr.io/reuteras/miniflux-tui:v0.5.4` (version tag)
- ✅ `ghcr.io/reuteras/miniflux-tui:latest` (latest tag)

This created unnecessary tag clutter and didn't align with semantic versioning.

## Problem 2: Empty Release Notes
The publish workflow created draft releases with empty notes:
```bash
gh release create "${TAG}" --draft --verify-tag --title "${TAG}" --notes "" --repo "${REPO}"
```

This resulted in releases like v0.5.4 showing up as drafts with no description.

## Changes

### Container Image Workflow (`.github/workflows/container-image.yml`)
- **Removed**: Commit SHA tag generation (line 82)
- **Result**: Only version tags and `latest` are published

**Before:**
```yaml
tags+=$'\n'"${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA:0:7}"
```

**After:**
```yaml
# Removed - no more SHA tags
```

### Publish Workflow (`.github/workflows/publish.yml`)
- **Added**: Automatic release notes linking to CHANGELOG.md
- **Result**: Draft releases include proper description

**Before:**
```bash
--notes ""
```

**After:**
```bash
RELEASE_NOTES="See [CHANGELOG.md](https://github.com/${REPO}/blob/main/CHANGELOG.md#${VERSION//.}) for details."
--notes "${RELEASE_NOTES}"
```

## Testing
- Container tags: Will take effect on next tag push (v0.5.5)
- Release notes: v0.5.4 manually updated with `gh release edit`
- Future releases will automatically include proper notes

## Benefits
✅ Cleaner container registry (no SHA clutter)
✅ Professional-looking releases with descriptions
✅ Consistent with semantic versioning practices
✅ Easy to find specific versions