### PR TITLE
Fix scraper helper UI layout issues

### DIFF
--- a/miniflux_tui/ui/screens/scraping_helper.py
+++ b/miniflux_tui/ui/screens/scraping_helper.py
@@ -42,6 +42,11 @@ class ScrapingHelperScreen(Screen):
         padding: 1 2;
     }
 
+    #feed-display {
+        margin-bottom: 1;
+        color: $text;
+    }
+
     #url-display {
         margin-bottom: 1;
         color: $accent;
@@ -49,15 +54,12 @@ class ScrapingHelperScreen(Screen):
 
     #status-message {
         height: auto;
-        min-height: 3;
         margin-bottom: 1;
-        border: solid $primary;
-        padding: 1;
+        padding: 0 1;
     }
 
     #candidates-container {
         height: auto;
-        max-height: 15;
         border: solid $primary;
         margin-bottom: 1;
     }
@@ -70,12 +72,12 @@ class ScrapingHelperScreen(Screen):
     }
 
     #candidates-list {
-        height: 1fr;
+        height: auto;
+        max-height: 10;
     }
 
     #preview-container {
         height: 1fr;
-        min-height: 20;
         border: solid $secondary;
     }
 


### PR DESCRIPTION
## Changes

This PR fixes several UI layout issues in the scraping helper screen:

1. **Status message**: Removed border and reduced padding to save space
2. **Candidates list**: Changed from fixed height to auto-sizing with max-height so it only takes up needed space
3. **Preview container**: Removed min-height constraint to allow better fitting on screen
4. **Feed display**: Added proper CSS styling

## Issues Fixed
- Status message box now borderless (saves vertical space)
- Candidates list dynamically sizes to content instead of always showing 10+ rows
- Preview fits better on screen without unnecessary height constraints

Fixes #413