### PR TITLE
fix: enable auto-merge and poll for PR merge completion in release wo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,17 +217,60 @@ jobs:
             exit 1
           fi
 
-      - name: Merge PR
+      - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.prepare-release.outputs.pr_number }}
         run: |
-          # Merge immediately (not --auto) since we already waited for CI checks
-          gh pr merge "$PR_NUMBER" --squash --delete-branch
+          # Enable auto-merge - PR will be merged automatically after required approvals
+          # (auto-approve.yml provides 1 approval, need 1 more manual approval)
+          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
+          echo "::notice::Auto-merge enabled for PR #$PR_NUMBER - waiting for required approvals"
 
-          # Wait for merge to fully propagate
-          echo "Waiting for merge to propagate..."
-          sleep 5
+      - name: Wait for PR to be merged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.prepare-release.outputs.pr_number }}
+        run: |
+          MAX_WAIT=1800  # 30 minutes - allows time for manual approval
+          ELAPSED=0
+          CHECK_INTERVAL=30  # Check every 30 seconds
+
+          echo "Waiting for PR #$PR_NUMBER to be merged (requires 2 approvals)..."
+          echo "- Auto-approve workflow provides 1 approval"
+          echo "- Requires 1 more manual approval from code owner"
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            # Check if PR is merged
+            PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+
+            if [ "$PR_STATE" = "MERGED" ]; then
+              echo "✅ PR #$PR_NUMBER has been merged!"
+              # Wait a bit longer for merge to fully propagate to all systems
+              echo "Waiting 10 seconds for merge to propagate..."
+              sleep 10
+              exit 0
+            fi
+
+            # Check if PR was closed without merging
+            if [ "$PR_STATE" = "CLOSED" ]; then
+              echo "::error::PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+
+            # Show approval status
+            REVIEW_DECISION=$(gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision // "PENDING"')
+            APPROVALS=$(gh pr view "$PR_NUMBER" --json reviews --jq '[.reviews[] | select(.state == "APPROVED")] | length')
+
+            echo "Status: $PR_STATE | Approvals: $APPROVALS/2 | Review Decision: $REVIEW_DECISION (${ELAPSED}s/${MAX_WAIT}s)"
+
+            sleep "$CHECK_INTERVAL"
+            ELAPSED=$((ELAPSED + CHECK_INTERVAL))
+          done
+
+          echo "::error::Timeout waiting for PR #$PR_NUMBER to be merged after ${MAX_WAIT} seconds"
+          echo "::error::Manual approval may be required. Please approve the PR and the workflow will continue."
+          exit 1
 
   create-tag:
     needs: [prepare-release, auto-merge]


### PR DESCRIPTION
…rkflow

## Problem
The release workflow failed with error: "Pull request is not mergeable: the base branch policy prohibits the merge." This happened because:

1. PR #434 added branch protection requiring 2 approvals + code owner review for OpenSSF Scorecard 10/10
2. PR #438 changed workflow to immediate merge (gh pr merge --squash) to fix timing issues with --auto
3. These two changes are incompatible:
   - Workflow tries to merge immediately
   - Branch protection requires 2 manual approvals
   - auto-approve.yml provides only 1 approval (via BOT_TOKEN)
   - Workflow doesn't wait for required second approval

## Root Cause
The immediate merge approach assumes no approval requirements, but branch protection now requires 2 approvals that cannot be provided automatically.

## Solution
Change the workflow to:
1. Enable auto-merge with --auto flag (not immediate merge)
2. Poll and wait for PR to actually be merged (after manual approvals)
3. Timeout after 30 minutes with clear error messages
4. Show approval status during polling for visibility

This is better than the old --auto approach because we actively wait for merge completion instead of just enabling auto-merge and moving on.

## Changes
- Changed "Merge PR" step to "Enable auto-merge"
  - Uses gh pr merge --auto --squash --delete-branch
  - Explains that auto-approve.yml provides 1 approval
- Added "Wait for PR to be merged" step
  - Polls PR state every 30 seconds
  - Shows approval progress (X/2 approvals)
  - Waits up to 30 minutes for manual approval
  - Fails if PR closed without merging
  - Waits 10 seconds after merge for propagation

## Benefits
- Compatible with branch protection requiring 2 approvals
- Maintains OpenSSF Scorecard 10/10 score
- Provides clear status during waiting
- Prevents timing issues with tag creation
- Fails gracefully with helpful error messages

## Testing
- Next release attempt should:
  1. Create PR successfully
  2. Get 1 auto-approval from auto-approve.yml
  3. Wait for 2nd manual approval
  4. Auto-merge after 2nd approval
  5. Create tag on correct commit

Related to: #440 (failed release)
Fixes: Conflict between PR #434 (branch protection) and PR #438 (immediate merge)