### PR TITLE
fix: handle PR number suffix in release commit message validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,9 +308,10 @@ jobs:
           git pull --ff-only origin main
 
           # Verify we're tagging a commit with the release message
+          # Note: GitHub appends PR number when merging, e.g. "chore: Release v0.5.6 (#443)"
           COMMIT_MSG=$(git log -1 --pretty=%s)
-          if [[ ! "$COMMIT_MSG" =~ ^chore:\ Release\ v${VERSION}$ ]]; then
-            echo "::error::Latest commit message does not match release: got '$COMMIT_MSG', expected 'chore: Release v${VERSION}'"
+          if [[ ! "$COMMIT_MSG" =~ ^chore:\ Release\ v${VERSION}(\ \(#[0-9]+\))?$ ]]; then
+            echo "::error::Latest commit message does not match release: got '$COMMIT_MSG', expected 'chore: Release v${VERSION}' (with optional PR number)"
             echo "::error::This usually means the PR merge hasn't propagated yet. Current commit:"
             git log -1 --oneline
             exit 1


### PR DESCRIPTION
## Problem
When GitHub merges a PR via squash merge, it automatically appends the PR number to the commit message (e.g., 'chore: Release v0.5.6 (#443)'). The release workflow was checking for an exact match without the PR number, causing the tag creation to fail with:

  Error: Latest commit message does not match release: got 'chore: Release
  v0.5.6 (#443)', expected 'chore: Release v0.5.6'

## Solution
Updated the regex pattern in the create-tag job to accept both formats:
- With PR number: chore: Release v0.5.6 (#443)
- Without PR number: chore: Release v0.5.6

The regex now includes an optional suffix: (\ \(#[0-9]+\))?

## Testing
The regex will now match both:
- Direct commits (unlikely but handled)
- PR merge commits with auto-appended PR numbers (normal case)

Fixes the release workflow failure in run that attempted to tag v0.5.6.