### PR TITLE
fix: enable manual triggering and automatic chaining of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g., v0.5.6)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -26,6 +32,7 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Install uv
@@ -116,6 +123,7 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Install uv
@@ -144,7 +152,7 @@ jobs:
     env:
       DIST_ARTIFACT_NAME: dist-${{ github.run_id }}-${{ github.run_attempt }}
       BINARY_ARTIFACT_PREFIX: miniflux-tui-${{ github.run_id }}-${{ github.run_attempt }}
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     needs: [build, binaries]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      actions: write
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -322,3 +323,15 @@ jobs:
           git push origin "$TAG"
 
           echo "::notice::Created and pushed signed tag: $TAG on commit $(git rev-parse HEAD)"
+
+      - name: Trigger publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          TAG="v${VERSION}"
+
+          echo "Triggering publish workflow for tag: $TAG"
+          gh workflow run publish.yml --ref main --field tag="$TAG"
+
+          echo "::notice::Triggered publish workflow for tag: $TAG"


### PR DESCRIPTION
## Problem
The publish workflow was not triggered when release workflow created tags because GitHub Actions workflows triggered by GITHUB_TOKEN do not trigger other workflows (security feature to prevent infinite loops).

## Solution
1. Added workflow_dispatch trigger to publish.yml:
   - Allows manual triggering with tag parameter
   - Enables running publish for existing tags (like v0.5.6)

2. Updated all checkout steps in publish.yml:
   - Use ${{ inputs.tag || github.ref }} to support both manual and automatic triggers

3. Updated RELEASE_TAG in publish.yml:
   - Use ${{ inputs.tag || github.ref_name }} for correct tag resolution

4. Added automatic trigger in release.yml:
   - After creating tag, explicitly trigger publish workflow using gh workflow run
   - Added actions: write permission to create-tag job

## Benefits
- Immediate fix: Can manually run publish workflow for v0.5.6
- Long-term fix: Future releases will automatically trigger publish workflow
- No breaking changes: Existing tag-based triggers still work

## Testing
- Manually trigger publish workflow via GitHub UI for v0.5.6
- Future releases will automatically chain release → publish workflows