### PR TITLE
fix: replace overly broad exception handlers with specific exception …

### DIFF
--- a/miniflux_tui/security.py
+++ b/miniflux_tui/security.py
@@ -5,7 +5,7 @@ import re
 from urllib.parse import urlparse
 
 
-def validate_feed_url(url: str) -> tuple[bool, str]:  # noqa: PLR0911, PLR0912
+def validate_feed_url(url: str) -> tuple[bool, str]:  # noqa: PLR0911
     """Validate and sanitize feed URL for SSRF prevention.
 
     Args:
@@ -22,11 +22,8 @@ def validate_feed_url(url: str) -> tuple[bool, str]:  # noqa: PLR0911, PLR0912
     if not url.strip():
         return False, "URL cannot be empty"
 
-    # Parse URL
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return False, "Invalid URL format"  # pragma: no cover
+    # Parse URL (urlparse doesn't raise exceptions, just returns parsed components)
+    parsed = urlparse(url)
 
     # Protocol whitelist - only HTTP and HTTPS allowed
     if parsed.scheme not in ["http", "https"]:

--- a/miniflux_tui/utils.py
+++ b/miniflux_tui/utils.py
@@ -84,7 +84,8 @@ def _iter_distribution_candidates() -> Iterator[str]:
 
     try:
         packages = metadata.packages_distributions()
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
+        # packages_distributions() might not exist or might fail in some environments
         return
 
     for candidate in packages.get("miniflux_tui", []) or []:
@@ -182,7 +183,8 @@ def extract_images_from_html(html_content: str, base_url: str | None = None) -> 
                 image_urls.append(src)
 
         return image_urls
-    except Exception:
+    except (ValueError, TypeError, AttributeError):
+        # HTML parsing can fail with malformed content or invalid data types
         return []
 
 


### PR DESCRIPTION
…types

## Changes
- security.py:28 - Remove unnecessary try/except around urlparse (doesn't raise exceptions)
- security.py:8 - Remove unused PLR0912 noqa directive
- utils.py:87 - Replace bare 'except Exception' with specific exception types (AttributeError, TypeError, ValueError)
- utils.py:185 - Replace bare 'except Exception' with specific exception types (ValueError, TypeError, AttributeError)

## Security Impact
Addresses code scanning alerts #281, #282, #283 by making exception handling more explicit and preventing silent error suppression. This improves:
- Debugging by allowing unexpected exceptions to propagate
- Security by not hiding security-relevant errors
- Code maintainability by documenting expected exception types

## Testing
- ✅ All 913 tests pass
- ✅ Linting passes (ruff check)
- ✅ Type checking passes (pyright)
- ✅ Code coverage maintained at 74%