### PR TITLE
Test on Version 3

### DIFF
--- a/miniflux_tui/ui/screens/entry_reader.py
+++ b/miniflux_tui/ui/screens/entry_reader.py
@@ -27,7 +27,7 @@ from miniflux_tui.utils import (
 # Optional image support - gracefully handle when textual-image is not available
 # Use TYPE_CHECKING to avoid import errors during static analysis when library is not installed
 if TYPE_CHECKING:
-    from textual_image.widget import Image
+    from textual_image.widget import Image  # type: ignore[import-not-found]
 
     IMAGE_SUPPORT: bool
 else:

--- a/miniflux_tui/ui/screens/help.py
+++ b/miniflux_tui/ui/screens/help.py
@@ -18,7 +18,7 @@ from miniflux_tui.utils import get_app_version
 
 # Optional image support - same pattern as entry_reader.py
 if TYPE_CHECKING:
-    from textual_image.widget import Image
+    from textual_image.widget import Image  # type: ignore[import-not-found]
 
     IMAGE_SUPPORT: bool
 else:


### PR DESCRIPTION
## Problem
Python 3.14 CI tests were failing because pyright could not resolve textual_image imports. The package is restricted to Python < 3.14 in dependencies, so pyright cannot find it during type checking even though the import is guarded by TYPE_CHECKING.

## Solution
Added `# type: ignore[import-not-found]` to the textual_image imports inside TYPE_CHECKING blocks in both entry_reader.py and help.py.

## Changes
- miniflux_tui/ui/screens/entry_reader.py: Added type ignore comment
- miniflux_tui/ui/screens/help.py: Added type ignore comment

## Testing
- ✅ pyright passes with 0 errors locally
- ✅ Imports still work correctly at runtime (try/except handles missing package)
- ✅ Type checking works for Python versions where textual_image is available

Fixes Python 3.14 CI pyright failures