### PR TITLE
Debugging an error message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7
@@ -295,7 +294,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gitsign
         uses: chainguard-dev/actions/setup-gitsign@1b32103f5aa389c31ab0be75a8edc38d7e4750d8 # main


### PR DESCRIPTION
## Problem
The release workflow was failing with authentication error: 'fatal: could not read Username for https://github.com'

## Root Cause
- prepare-release job: Had persist-credentials: false but needed to git push
- create-tag job: Had persist-credentials: false but needed to git pull/push

## Solution
- prepare-release: Removed persist-credentials: false (defaults to true)
- create-tag: Changed to token: ${{ secrets.GITHUB_TOKEN }}
- auto-merge: Left as-is (only uses gh CLI, doesn't need git auth)

## Testing
Next release workflow run should successfully push branches and tags.