### PR TITLE
fix: prevent credential persistence in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7
@@ -295,6 +296,7 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Gitsign
         uses: chainguard-dev/actions/setup-gitsign@1b32103f5aa389c31ab0be75a8edc38d7e4750d8 # main


### PR DESCRIPTION
## Description
Fixes code scanning security alerts #281 and #297 (zizmor/artipacked).

## Changes
- Added `persist-credentials: false` to both checkout actions in release.yml
- Prevents Git from storing the GitHub token in .git/config
- Mitigates risk of credentials being accidentally included in artifacts

## Security Impact
This prevents credential persistence that could be exposed if the workspace is uploaded as an artifact.