### PR TITLE
fix: Enable git credentials persistence in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7
@@ -296,7 +295,6 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
 
       - name: Setup Gitsign
         uses: chainguard-dev/actions/setup-gitsign@1b32103f5aa389c31ab0be75a8edc38d7e4750d8 # main


### PR DESCRIPTION
## Problem
The release workflow fails with authentication error when trying to push: 'fatal: could not read Username for https://github.com'

This affects both v0.5.11 and v0.5.12 release attempts.

## Root Cause
Two jobs had persist-credentials: false but needed to perform git push:
- prepare-release job: Needs to push release branch
- create-tag job: Needs to pull latest main and push tags

## Solution
Removed persist-credentials: false from both jobs to allow credentials to persist:
- prepare-release job (line 40-43): Removed persist-credentials: false
- create-tag job (line 293-297): Removed persist-credentials: false
- auto-merge job: Left unchanged (only uses gh CLI)

## Testing
- Next release workflow should successfully push branches and tags
- Fixes both the release branch push and tag push operations