### PR TITLE
fix: re-add persist-credentials false to all checkouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7
@@ -299,6 +300,7 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Gitsign
         uses: chainguard-dev/actions/setup-gitsign@1b32103f5aa389c31ab0be75a8edc38d7e4750d8 # main


### PR DESCRIPTION
## Problem
Security alerts #281 and #297 returned after PR #466 inadvertently removed the `persist-credentials: false` setting from two checkout actions that was added in PR #465.

## Changes
Re-adds `persist-credentials: false` to:
- Line 40-44: prepare-release job checkout
- Line 297-303: create-tag job checkout

## Why This Matters
Without `persist-credentials: false`, Git stores the GitHub token in `.git/config`, which could be exposed if the workspace is uploaded as an artifact (zizmor/artipacked warning).

Resolves security alerts #281 and #297.