### PR TITLE
Review and fix failing tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -539,3 +539,165 @@ group_collapsed = true
             assert config.default_sort == "status"
             assert config.default_group_by_feed is True
             assert config.group_collapsed is True
+
+
+class TestCreateCodespaceConfig:
+    """Test Codespace configuration creation."""
+
+    def test_create_codespace_config_creates_file(self, tmp_path):
+        """Test create_codespace_config() creates configuration file."""
+        config_dir = tmp_path / "miniflux-tui"
+
+        with patch("miniflux_tui.config.get_config_dir") as mock_get_dir:
+            mock_get_dir.return_value = config_dir
+            config_path = config_module.create_codespace_config()
+
+            assert config_path.exists()
+            assert config_path == config_dir / "config.toml"
+
+    def test_create_codespace_config_content_unix(self, tmp_path):
+        """Test create_codespace_config() creates correct content on Unix."""
+        config_dir = tmp_path / "miniflux-tui"
+
+        with (
+            patch("miniflux_tui.config.get_config_dir") as mock_get_dir,
+            patch("miniflux_tui.config.sys.platform", "linux"),
+        ):
+            mock_get_dir.return_value = config_dir
+            config_path = config_module.create_codespace_config()
+
+            content = config_path.read_text()
+            assert "MINIFLUX_SERVER_URL" in content
+            assert "MINIFLUX_API_KEY" in content
+            assert '["sh", "-c", "echo $MINIFLUX_API_KEY"]' in content
+            assert "PLACEHOLDER_SET_MINIFLUX_SERVER_URL_SECRET" in content
+            assert "default_group_by_feed = true" in content
+
+    def test_create_codespace_config_content_windows(self, tmp_path):
+        """Test create_codespace_config() creates correct content on Windows."""
+        config_dir = tmp_path / "miniflux-tui"
+
+        with (
+            patch("miniflux_tui.config.get_config_dir") as mock_get_dir,
+            patch("miniflux_tui.config.sys.platform", "win32"),
+        ):
+            mock_get_dir.return_value = config_dir
+            config_path = config_module.create_codespace_config()
+
+            content = config_path.read_text()
+            assert '["cmd", "/c", "echo %MINIFLUX_API_KEY%"]' in content
+
+    def test_create_codespace_config_creates_directory(self, tmp_path):
+        """Test create_codespace_config() creates config directory if it doesn't exist."""
+        config_dir = tmp_path / "miniflux-tui"
+        assert not config_dir.exists()
+
+        with patch("miniflux_tui.config.get_config_dir") as mock_get_dir:
+            mock_get_dir.return_value = config_dir
+            config_path = config_module.create_codespace_config()
+
+            assert config_dir.exists()
+            assert config_path.exists()
+
+    def test_create_codespace_config_overwrites_existing(self, tmp_path):
+        """Test create_codespace_config() overwrites existing file."""
+        config_dir = tmp_path / "miniflux-tui"
+        config_dir.mkdir()
+        config_file = config_dir / "config.toml"
+        config_file.write_text("old config")
+
+        with patch("miniflux_tui.config.get_config_dir") as mock_get_dir:
+            mock_get_dir.return_value = config_dir
+            config_path = config_module.create_codespace_config()
+
+            content = config_path.read_text()
+            assert "old config" not in content
+            assert "MINIFLUX_SERVER_URL" in content
+
+
+class TestConfigEnvVarOverride:
+    """Test environment variable override functionality."""
+
+    def test_env_var_overrides_server_url(self, tmp_path, monkeypatch):
+        """Test MINIFLUX_SERVER_URL environment variable overrides config."""
+        monkeypatch.setenv("MINIFLUX_SERVER_URL", "https://env-server.com")
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+server_url = "https://config-server.com"
+password = ["echo", "test-token"]
+""")
+
+        config = Config.from_file(config_file)
+        assert config.server_url == "https://env-server.com"
+
+    def test_config_value_used_without_env_var(self, tmp_path, monkeypatch):
+        """Test config value is used when environment variable is not set."""
+        monkeypatch.delenv("MINIFLUX_SERVER_URL", raising=False)
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+server_url = "https://config-server.com"
+password = ["echo", "test-token"]
+""")
+
+        config = Config.from_file(config_file)
+        assert config.server_url == "https://config-server.com"
+
+    def test_placeholder_without_env_var_raises_error(self, tmp_path, monkeypatch):
+        """Test placeholder in config raises error without environment variable."""
+        monkeypatch.delenv("MINIFLUX_SERVER_URL", raising=False)
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+server_url = "https://PLACEHOLDER_SET_MINIFLUX_SERVER_URL_SECRET"
+password = ["echo", "test-token"]
+""")
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            Config.from_file(config_file)
+
+        assert "placeholder" in str(exc_info.value).lower()
+        assert "MINIFLUX_SERVER_URL" in str(exc_info.value)
+
+    def test_placeholder_with_env_var_succeeds(self, tmp_path, monkeypatch):
+        """Test placeholder in config works with environment variable."""
+        monkeypatch.setenv("MINIFLUX_SERVER_URL", "https://env-server.com")
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+server_url = "https://PLACEHOLDER_SET_MINIFLUX_SERVER_URL_SECRET"
+password = ["echo", "test-token"]
+""")
+
+        config = Config.from_file(config_file)
+        assert config.server_url == "https://env-server.com"
+
+    def test_env_var_override_with_all_settings(self, tmp_path, monkeypatch):
+        """Test environment variable override preserves other settings."""
+        monkeypatch.setenv("MINIFLUX_SERVER_URL", "https://env-server.com")
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""
+server_url = "https://config-server.com"
+password = ["echo", "test-token"]
+allow_invalid_certs = true
+
+[theme]
+unread_color = "blue"
+read_color = "red"
+
+[sorting]
+default_sort = "feed"
+default_group_by_feed = true
+group_collapsed = true
+""")
+
+        config = Config.from_file(config_file)
+        assert config.server_url == "https://env-server.com"
+        assert config.allow_invalid_certs is True
+        assert config.unread_color == "blue"
+        assert config.read_color == "red"
+        assert config.default_sort == "feed"
+        assert config.default_group_by_feed is True
+        assert config.group_collapsed is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,52 @@ class TestMainInit:
             assert result == 0
 
 
+class TestMainInitCodespace:
+    """Test --init-codespace flag functionality."""
+
+    def test_init_codespace_creates_config(self, tmp_path):
+        """Test --init-codespace flag creates configuration file."""
+        config_path = tmp_path / "config.toml"
+
+        with patch("miniflux_tui.main.create_codespace_config") as mock_create:
+            mock_create.return_value = config_path
+            with patch.object(sys, "argv", ["miniflux-tui", "--init-codespace"]):
+                result = main()
+
+            assert result == 0
+            mock_create.assert_called_once()
+
+    def test_init_codespace_prints_help_message(self, tmp_path, capsys):
+        """Test --init-codespace flag prints helpful message."""
+        config_file = tmp_path / "config.toml"
+
+        with patch("miniflux_tui.main.create_codespace_config") as mock_create:
+            mock_create.return_value = config_file
+            with patch.object(sys, "argv", ["miniflux-tui", "--init-codespace"]):
+                result = main()
+
+            captured = capsys.readouterr()
+            assert "Created GitHub Codespaces configuration" in captured.out
+            assert "environment variables" in captured.out
+            assert "MINIFLUX_SERVER_URL" in captured.out
+            assert "MINIFLUX_API_KEY" in captured.out
+            assert result == 0
+
+    def test_init_codespace_mentions_tailscale(self, tmp_path, capsys):
+        """Test --init-codespace includes Tailscale setup instructions."""
+        config_file = tmp_path / "config.toml"
+
+        with patch("miniflux_tui.main.create_codespace_config") as mock_create:
+            mock_create.return_value = config_file
+            with patch.object(sys, "argv", ["miniflux-tui", "--init-codespace"]):
+                result = main()
+
+            captured = capsys.readouterr()
+            assert "Tailscale" in captured.out
+            assert "TAILSCALE_AUTHKEY" in captured.out
+            assert result == 0
+
+
 class TestMainCheckConfig:
     """Test --check-config flag functionality."""
 
@@ -289,6 +335,190 @@ class TestMainArgumentParsing:
             with patch.object(sys, "argv", ["miniflux-tui", "--check-config"]):
                 result = main()
                 assert result == 0
+
+
+class TestAutoCreateCodespaceConfig:
+    """Test automatic Codespace configuration creation."""
+
+    def test_auto_create_with_env_vars(self, tmp_path, monkeypatch, capsys):
+        """Test auto-creation when environment variables are present."""
+        # Set environment variables
+        monkeypatch.setenv("MINIFLUX_SERVER_URL", "https://example.com")
+        monkeypatch.setenv("MINIFLUX_API_KEY", TEST_TOKEN)
+
+        config_path = tmp_path / "config.toml"
+
+        mock_config = MagicMock()
+        with (
+            patch("miniflux_tui.main.get_config_file_path") as mock_path,
+            patch("miniflux_tui.main.create_codespace_config") as mock_create,
+            patch("miniflux_tui.main.load_config") as mock_load,
+            patch("miniflux_tui.main.run_tui", new=AsyncMock()),
+        ):
+            mock_path.return_value = config_path
+            mock_create.return_value = config_path
+            mock_load.return_value = mock_config
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                result = main()
+
+            captured = capsys.readouterr()
+            assert "Detected Codespace environment variables" in captured.out
+            assert "Automatically creating Codespace configuration" in captured.out
+            assert result == 0
+            mock_create.assert_called_once()
+
+    def test_auto_create_skipped_when_config_exists(self, tmp_path, monkeypatch):
+        """Test auto-creation is skipped if config already exists."""
+        # Set environment variables
+        monkeypatch.setenv("MINIFLUX_SERVER_URL", "https://example.com")
+        monkeypatch.setenv("MINIFLUX_API_KEY", TEST_TOKEN)
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("existing config")
+
+        mock_config = MagicMock()
+        with (
+            patch("miniflux_tui.main.get_config_file_path") as mock_path,
+            patch("miniflux_tui.main.create_codespace_config") as mock_create,
+            patch("miniflux_tui.main.load_config") as mock_load,
+            patch("miniflux_tui.main.run_tui", new=AsyncMock()),
+        ):
+            mock_path.return_value = config_path
+            mock_load.return_value = mock_config
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                main()
+
+            # Should not create config since it exists
+            mock_create.assert_not_called()
+
+    def test_auto_create_skipped_without_env_vars(self, tmp_path, monkeypatch):
+        """Test auto-creation is skipped without environment variables."""
+        # Ensure env vars are NOT set
+        monkeypatch.delenv("MINIFLUX_SERVER_URL", raising=False)
+        monkeypatch.delenv("MINIFLUX_API_KEY", raising=False)
+
+        config_path = tmp_path / "config.toml"
+
+        with (
+            patch("miniflux_tui.main.get_config_file_path") as mock_path,
+            patch("miniflux_tui.main.create_codespace_config") as mock_create,
+            patch("miniflux_tui.main.load_config") as mock_load,
+        ):
+            mock_path.return_value = config_path
+            mock_load.return_value = None
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                main()
+
+            # Should not create config without env vars
+            mock_create.assert_not_called()
+
+
+class TestAutoSetupTailscale:
+    """Test automatic Tailscale setup."""
+
+    def test_tailscale_setup_with_authkey_and_installed(self, tmp_path, monkeypatch, capsys):
+        """Test Tailscale authentication when already installed."""
+        monkeypatch.setenv("TAILSCALE_AUTHKEY", "test-authkey")
+
+        config_dir = tmp_path / "miniflux-tui"
+        marker_file = config_dir / ".tailscale-initialized"
+
+        mock_config = MagicMock()
+        with (
+            patch("miniflux_tui.main.get_config_dir") as mock_dir,
+            patch("miniflux_tui.main.shutil.which") as mock_which,
+            patch("miniflux_tui.main.subprocess.run") as mock_run,
+            patch("miniflux_tui.main.load_config") as mock_load,
+            patch("miniflux_tui.main.run_tui", new=AsyncMock()),
+        ):
+            mock_dir.return_value = str(config_dir)
+            mock_which.return_value = "/usr/bin/tailscale"
+            mock_load.return_value = mock_config
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                main()
+
+            captured = capsys.readouterr()
+            assert "Authenticating Tailscale" in captured.out
+
+            # Verify marker file was created
+            assert marker_file.exists()
+
+            # Verify tailscale command was called
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            assert call_args == ["/usr/bin/tailscale", "set", "--accept-routes"]
+
+    def test_tailscale_setup_skipped_without_authkey(self, monkeypatch, capsys):
+        """Test Tailscale setup is skipped without TAILSCALE_AUTHKEY."""
+        monkeypatch.delenv("TAILSCALE_AUTHKEY", raising=False)
+
+        mock_config = MagicMock()
+        with (
+            patch("miniflux_tui.main.shutil.which") as mock_which,
+            patch("miniflux_tui.main.load_config") as mock_load,
+            patch("miniflux_tui.main.run_tui", new=AsyncMock()),
+        ):
+            mock_load.return_value = mock_config
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                main()
+
+            captured = capsys.readouterr()
+            assert "Tailscale" not in captured.out
+            mock_which.assert_not_called()
+
+    def test_tailscale_setup_skipped_if_already_run(self, tmp_path, monkeypatch):
+        """Test Tailscale setup is skipped if marker file exists."""
+        monkeypatch.setenv("TAILSCALE_AUTHKEY", "test-authkey")
+
+        config_dir = tmp_path / "miniflux-tui"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        marker_file = config_dir / ".tailscale-initialized"
+        marker_file.touch()
+
+        mock_config = MagicMock()
+        with (
+            patch("miniflux_tui.main.get_config_dir") as mock_dir,
+            patch("miniflux_tui.main.shutil.which") as mock_which,
+            patch("miniflux_tui.main.subprocess.run") as mock_run,
+            patch("miniflux_tui.main.load_config") as mock_load,
+            patch("miniflux_tui.main.run_tui", new=AsyncMock()),
+        ):
+            mock_dir.return_value = str(config_dir)
+            mock_load.return_value = mock_config
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                main()
+
+            # Should not attempt Tailscale setup
+            mock_which.assert_not_called()
+            mock_run.assert_not_called()
+
+    def test_tailscale_installation_when_not_found(self, tmp_path, monkeypatch, capsys):
+        """Test Tailscale installation when not installed."""
+        monkeypatch.setenv("TAILSCALE_AUTHKEY", "test-authkey")
+
+        config_dir = tmp_path / "miniflux-tui"
+
+        mock_config = MagicMock()
+        with (
+            patch("miniflux_tui.main.get_config_dir") as mock_dir,
+            patch("miniflux_tui.main.shutil.which") as mock_which,
+            patch("miniflux_tui.main.subprocess.run") as mock_run,
+            patch("miniflux_tui.main.load_config") as mock_load,
+            patch("miniflux_tui.main.run_tui", new=AsyncMock()),
+        ):
+            mock_dir.return_value = str(config_dir)
+            # First call returns None (tailscale not found), second returns sh path, third returns tailscale path
+            mock_which.side_effect = [None, "/bin/sh", "/usr/bin/tailscale"]
+            mock_load.return_value = mock_config
+            with patch.object(sys, "argv", ["miniflux-tui"]):
+                main()
+
+            captured = capsys.readouterr()
+            assert "Installing Tailscale" in captured.out
+            assert "Tailscale installed successfully" in captured.out
+
+            # Should call subprocess twice: once for install, once for auth
+            assert mock_run.call_count == 2
 
 
 class TestMainEntryPoint:


### PR DESCRIPTION
## Changes
- Add tests for --init-codespace CLI flag
- Add tests for create_codespace_config() function
- Add tests for automatic config creation with env vars
- Add tests for automatic Tailscale setup
- Add tests for environment variable override in Config.from_file()

## Test Coverage
Added 20 new tests covering:
- CLI flag handling for codespace initialization
- Codespace config file creation (Unix & Windows)
- Auto-detection and creation when env vars are present
- Tailscale installation and authentication flow
- Environment variable override behavior
- Placeholder detection and validation

## Testing
- All 967 tests passing (947 → 967, +20 new tests)
- ruff check: passed
- ruff format: passed
- pyright: 0 errors

Fixes missing test coverage for codespace functionality added in #484-#487