### PR TITLE
feat: add Tailscale support to GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,10 @@
 {
     "name": "miniflux-tui-py",
     "image": "mcr.microsoft.com/devcontainers/python:3.14-bookworm",
-
-    // Enable Tailscale in Codespaces
     "runArgs": ["--device=/dev/net/tun"],
-
     "features": {
         "ghcr.io/tailscale/codespace/tailscale": {}
     },
-
     "postCreateCommand": "bash .devcontainer/postCreate.sh",
     "postStartCommand": "bash .devcontainer/postStart.sh",
     "remoteEnv": {


### PR DESCRIPTION
## Changes
- Add runArgs with /dev/net/tun device for Tailscale networking
- Add Tailscale Codespace feature from ghcr.io/tailscale/codespace/tailscale

## References
- Tailscale Codespaces documentation: https://tailscale.com/kb/1160/github-codespaces

This enables secure Tailscale VPN connectivity within GitHub Codespaces, allowing the development environment to access resources on the Tailscale network.