### PR TITLE
Debug highlight position mismatch issue

### DIFF
--- a/miniflux_tui/ui/app.py
+++ b/miniflux_tui/ui/app.py
@@ -332,7 +332,13 @@ class MinifluxTuiApp(App):
                 self.log("entry_list screen is installed")
                 self.log(f"Updating screen with {len(self.entries)} entries")
                 entry_list_screen.entries = self.entries
-                entry_list_screen._populate_list()
+                # Only populate if screen is currently shown (mounted)
+                # Otherwise, let on_mount() or on_screen_resume() handle it
+                if entry_list_screen.is_current:
+                    self.log("Screen is current - populating now")
+                    entry_list_screen._populate_list()
+                else:
+                    self.log("Screen is not current - will populate on mount/resume")
             else:
                 self.log("entry_list screen is NOT installed!")
 


### PR DESCRIPTION
## Problem
When starting the application, there was a mismatch between the visual highlighting and the actual cursor position. This caused:
- Visual highlight on first item, but cursor at wrong position
- Enter key doing nothing
- j/k keys not working as expected

This bug occurred in the real app but not in tests.

## Root Cause
During startup, `_populate_list()` was being called TWICE:

1. From `app.py:335` in `load_entries()` - BEFORE screen is pushed
2. From `entry_list.py:256` in `on_mount()` - AFTER screen is pushed

The first call happened when the screen was installed but NOT mounted, causing cursor restoration to fail or behave incorrectly. Then on_mount() called _populate_list() again, but the cursor state was already corrupted.

## Solution
Check if the screen is currently shown (`is_current`) before calling `_populate_list()` from app.py. If the screen is not visible, skip the population and let the screen's lifecycle methods (on_mount or on_screen_resume) handle it when the screen is actually mounted.

This ensures cursor restoration only happens when:
- The screen is fully mounted and visible
- The ListView is properly initialized
- Focus management works correctly

## Testing
✅ All 402 entry-related tests pass
✅ All 13 cursor position tests pass
✅ All 170 entry_list tests pass
✅ Ruff linting passes
✅ Pyright type checking passes (0 errors)

## Related
This fixes the startup cursor mismatch issue while preserving the previous fix for cursor restoration after returning from entry reader.