### PR TITLE
Review Pull Request

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -7,3 +7,4 @@ query-filters:
       id: py/possible-timing-attack-sensitive-info
       paths:
         - scripts/build_binary.py
+        - miniflux_tui/config.py  # Line 328: Checking for "password" keyword in error message, not comparing secrets


### PR DESCRIPTION
…r check

## Summary
Adds miniflux_tui/config.py to CodeQL timing attack exclusions for line 328.

## Issue
CodeQL flagged `if "password" in error_msg.lower()` at config.py:328 as a potential timing attack vulnerability (py/possible-timing-attack-sensitive-info).

## Root Cause
The code checks if the literal string "password" appears in a validation error message to provide helpful migration hints. This is NOT comparing secrets or sensitive data - it's checking for the presence of a keyword in an error message.

## Solution
Added config.py to the existing timing attack exclusion filter, with a comment explaining why this is a false positive.

## Security Analysis
- Line 328 checks: `if "password" in error_msg.lower()`
- Purpose: Detect missing password field to show migration instructions
- Not a timing attack risk because:
  - error_msg contains validation error text (not secrets)
  - "password" is a literal keyword (not user-provided)
  - No actual password/token comparison occurs

## Testing
- ✅ All 960 tests pass
- ✅ No complexity issues (pyscn check)
- ✅ No security issues (bandit -ll)
- ✅ CodeQL will now skip this false positive

## Related
- PR #511 - Code complexity improvements
- config.py:328 - Password field migration helper