### PR TITLE
Review and fix errors in PR #511

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,3 +8,5 @@ query-filters:
       paths:
         - scripts/build_binary.py
         - miniflux_tui/config.py  # Line 328: Checking for "password" keyword in error message, not comparing secrets
+        - tests/test_main.py  # Lines 174, 263: Test assertions checking "password" in output, not comparing secrets
+        - tests/test_config.py  # Line 364: Test assertion checking "password" in error message, not comparing secrets


### PR DESCRIPTION
## Summary
Adds test files to CodeQL timing attack exclusions to suppress false positive warnings for test assertions checking "password" keyword in error messages.

## Issue
CodeQL flagged multiple test assertions as potential timing attack vulnerabilities (py/possible-timing-attack-sensitive-info):
- tests/test_main.py:174, 263
- tests/test_config.py:364

## Root Cause
Test assertions check if the literal string "password" appears in error messages to verify correct error handling. This is NOT comparing secrets or sensitive data - it's validating that error messages contain expected keywords.

## Solution
Added test files to the existing timing attack exclusion filter in .github/codeql/codeql-config.yml with explanatory comments for each file.

## Security Analysis
- Purpose: Test assertions verifying error message content
- Not a timing attack risk because:
  - Checking test output/error messages (not secrets)
  - "password" is a literal keyword (not user-provided)
  - No actual password/token comparison occurs
  - Test code, not production code

## Testing
- ✅ All 75 tests in test_main.py and test_config.py pass
- ✅ Linting clean (ruff check)
- ✅ Type checking passes (pyright)
- ✅ CodeQL will now skip these false positives

## Related
- PR #511 - Contains these timing attack false positives
- PR #513 - Fixed similar issue in config.py
- Addresses remaining timing attack warnings in test suite