### PR TITLE
fix: Remove duplicate and malformed docstring in config.py

### DIFF
--- a/miniflux_tui/config.py
+++ b/miniflux_tui/config.py
@@ -174,16 +174,6 @@ class Config:
         return self._password_command
 
     def _execute_password_command(self) -> str:
-        """Execute the password command and return the output.
-
-        Returns:
-            Stripped stdout from the command
-
-        api_key = self._execute_password_command()
-        self._api_key_cache = api_key
-        return api_key
-
-    def _execute_password_command(self) -> str:
         """Execute password command and return sanitized output.
 
         Returns:
@@ -227,6 +217,22 @@ class Config:
         if stderr:
             msg = f"{msg}: {stderr}"
         raise RuntimeError(msg) from exc
+
+    def get_api_key(self) -> str:
+        """Get the API key, using cache if available.
+
+        Returns:
+            The API key from cache or by executing the password command
+
+        Raises:
+            RuntimeError: If command fails or returns empty output
+        """
+        if self._api_key_cache is not None:
+            return self._api_key_cache
+
+        api_key = self._execute_password_command()
+        self._api_key_cache = api_key
+        return api_key
 
     @property
     def api_key(self) -> str:


### PR DESCRIPTION
## Changes
- Removed duplicate function definition of `_execute_password_command`
- Removed unterminated docstring with leftover code snippets
- Added missing `get_api_key()` method for API key caching
- Fixed SyntaxError: unterminated string literal at line 317

## Testing
- ✅ Python syntax validation passed
- ✅ Type checking passed
- ✅ Linting passed
- ✅ Program runs successfully (uv run miniflux-tui --help works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)