### PR TITLE
fix: Display feed statistics row on all entries in grouped mode and mark as read on open

### DIFF
--- a/miniflux_tui/ui/screens/entry_reader.py
+++ b/miniflux_tui/ui/screens/entry_reader.py
@@ -241,6 +241,13 @@ class EntryReaderScreen(Screen):
             try:
                 await app.client.mark_as_read(self.entry.id)
                 self.entry.status = "read"
+
+                # Also update the entry in the entry_list if it exists there
+                for entry in self.entry_list:
+                    if entry.id == self.entry.id:
+                        entry.status = "read"
+                        break
+
                 # Update sub_title to reflect new unread count
                 self._update_sub_title()
             except Exception as e:
@@ -516,6 +523,11 @@ class EntryReaderScreen(Screen):
                 classes="entry-meta",
             )
         )
+
+        # Add group statistics if available
+        group_stats_text = self._get_group_stats_text()
+        if group_stats_text:
+            scroll.mount(Static(group_stats_text, classes="entry-meta"))
 
     def _mount_url(self, scroll: VerticalScroll):
         """Mount entry URL widget."""


### PR DESCRIPTION
## Summary
This fix addresses two issues with the entry reader in grouped mode:

1. **Feed statistics row missing when navigating entries**: The "Feed: X unread / Y total" row was only appearing on the first entry when using J/K navigation in grouped mode. Now it's properly displayed for all entries.

2. **Entry not marked as read on open**: When opening an entry, it was marked as read locally but the change didn't propagate back to the entry list. Now the status is synced back to the entry_list so returning to the list shows the correct read status.

## Changes
- Fixed `_mount_metadata()` in entry_reader.py to display group statistics for every entry
- Updated `_mark_entry_as_read()` to sync status changes back to the entry_list
- Group statistics now properly recalculated and displayed during J/K navigation

## Testing
- All 960 tests passing
- Ruff linting: clean
- Pyright type checking: 0 errors
- Pre-commit hooks: all passing

## Related Issues
Fixes issues with entry reader display and synchronization in grouped mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)