### PR TITLE
fix: Implement comprehensive SafeHeader watcher-based exception handling for Windows Python 3.11+

### DIFF
--- a/miniflux_tui/ui/widgets/safe_widgets.py
+++ b/miniflux_tui/ui/widgets/safe_widgets.py
@@ -9,7 +9,6 @@ from contextlib import suppress
 
 from textual.css.query import NoMatches
 from textual.dom import NoScreen
-from textual.events import Mount
 from textual.widgets._header import Header, HeaderTitle
 
 
@@ -37,13 +36,28 @@ class SafeHeader(Header):
         with suppress(NoMatches, NoScreen):
             self.query_one(HeaderTitle).update(self.format_title())
 
-    def _on_mount(self, _: Mount) -> None:
+    def _on_mount(self, _) -> None:
         """Called when the Header is mounted, with improved exception handling.
 
-        This override defers title setting to the next event loop iteration,
-        allowing HeaderTitle to be fully mounted before we try to query it.
-        This handles platform-specific timing issues on Windows Python 3.11+.
+        This override catches NoMatches in addition to NoScreen, fixing
+        Windows-specific timing issues where HeaderTitle isn't ready yet.
         """
-        # Defer title setting to next event loop iteration
-        # This ensures HeaderTitle is mounted and ready before we query it
-        self.call_later(self.set_title)
+
+        def set_title_safe() -> None:
+            """Set the title with comprehensive exception handling."""
+            # Suppress both NoMatches (Windows timing) and NoScreen (context issues)
+            # This handles cases where HeaderTitle hasn't been created yet
+            with suppress(NoMatches, NoScreen):
+                self.query_one(HeaderTitle).update(self.format_title())
+
+        # Set up watchers that call set_title_safe when title/sub_title changes
+        # Using a sync callback ensures it runs immediately when properties change
+        self.watch(self.app, "title", set_title_safe)
+        self.watch(self.app, "sub_title", set_title_safe)
+        self.watch(self.screen, "title", set_title_safe)
+        self.watch(self.screen, "sub_title", set_title_safe)
+
+        # Also try to set title on mount to ensure it's displayed
+        # This handles the initial title display
+        with suppress(NoMatches, NoScreen):
+            self.query_one(HeaderTitle).update(self.format_title())


### PR DESCRIPTION
## Summary

This PR fixes Windows Python 3.11+ integration test failures where SafeHeader was raising `NoMatches` exceptions.

The root cause was that Textual's Header widget sets up watchers on `app.title`, `app.sub_title`, `screen.title`, and `screen.sub_title` properties. When these watchers fire during the widget lifecycle, they call the parent Header's `set_title()` method, which only catches `NoScreen` exceptions, not `NoMatches`. This caused failures on Windows where HeaderTitle widget timing is unpredictable.

## Changes

- Enhanced `_on_mount()` to register custom watchers with comprehensive exception handling
- Each watcher calls a `set_title_safe()` function that suppresses both `NoMatches` and `NoScreen`
- Also suppresses exceptions during initial mount to ensure title display
- Kept direct `set_title()` override for safety

## Why This Works

**Previous approach** (deferred callback with `call_later()`):
- Only addressed the `_on_mount` lifecycle
- Couldn't protect the watcher callbacks that fire during property changes
- Resulted in unhandled NoMatches exceptions on Windows

**New approach** (watcher-based):
- Catches exceptions at the source (the watcher callbacks)
- More reliable across all Windows Python versions
- Also protects direct method calls via `set_title()` override

## Testing

- ✅ All 1244 unit tests pass locally
- ✅ All 16 integration tests pass (including the previously failing test)
- ✅ Pre-commit hooks validated (ruff, pyright, etc.)
- ✅ Ready for full CI/CD testing on Windows/macOS/Linux and Python 3.11-3.15

## Related Issues

- Fixes: Windows Python 3.11+ integration test failures in `test_app_full_integration.py`
- References: PR #563 (previous SafeHeader improvements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)