### PR TITLE
fix: Prevent immutable release error in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -382,11 +382,11 @@ jobs:
           fi
 
           if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
-            echo "Release ${TAG} does not exist yet. Creating a release before uploading assets."
+            echo "Release ${TAG} does not exist yet. Creating a draft release before uploading assets."
             # Extract release notes from CHANGELOG.md for this version
             VERSION="${TAG#v}"
             RELEASE_NOTES="See [CHANGELOG.md](https://github.com/${REPO}/blob/main/CHANGELOG.md#${VERSION//.}) for details."
-            gh release create "${TAG}" --verify-tag --title "${TAG}" --notes "${RELEASE_NOTES}" --latest --repo "${REPO}"
+            gh release create "${TAG}" --draft --verify-tag --title "${TAG}" --notes "${RELEASE_NOTES}" --latest --repo "${REPO}"
           fi
 
           for required_dir in dist sbom; do
@@ -457,3 +457,6 @@ jobs:
           printf '  %s\n' "${upload_files[@]}"
 
           gh release upload "${TAG}" "${upload_files[@]}" --clobber --repo "${REPO}"
+
+          echo "Publishing the release ${TAG}..."
+          gh release edit "${TAG}" --draft=false --repo "${REPO}"


### PR DESCRIPTION
## Summary

Fixes #590 - Resolves HTTP 422 error when uploading assets to GitHub releases.

## Problem

The v0.7.0 release failed with:
```
HTTP 422: Cannot upload assets to an immutable release
```

The publish workflow was creating the release as **published/immutable** immediately, then trying to upload assets. GitHub rejects uploads to published releases.

## Changes

Modified `.github/workflows/publish.yml`:

1. **Line 389** - Added `--draft` flag to create release as draft:
   ```bash
   gh release create "${TAG}" --draft --verify-tag --title "${TAG}" --notes "${RELEASE_NOTES}" --latest --repo "${REPO}"
   ```

2. **Lines 461-462** - Added step to publish release after asset upload:
   ```bash
   echo "Publishing the release ${TAG}..."
   gh release edit "${TAG}" --draft=false --repo "${REPO}"
   ```

## Solution

The workflow now follows a three-step process:
1. **Create draft release** → Release exists but is mutable
2. **Upload all assets** → 20+ files (wheels, binaries, SBOMs, provenance, signatures)
3. **Publish release** → Convert draft to published/immutable

This ensures all assets are uploaded before the release becomes immutable.

## Testing

- [x] Pre-commit hooks passed
- [x] Workflow YAML syntax valid
- [ ] Manual workflow re-run to verify fix (after merge)

## Related Issues

Closes #590

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)