### PR TITLE
Fix NoMatches error when navigating entries with J/K keys

### DIFF
--- a/miniflux_tui/ui/screens/entry_reader.py
+++ b/miniflux_tui/ui/screens/entry_reader.py
@@ -141,7 +141,7 @@ class EntryReaderScreen(Screen):
         self.links = self._extract_links(content)
 
         # Scrollable markdown content (takes remaining height)
-        yield Markdown(content, classes="entry-content")
+        yield Markdown(content, id="entry-content", classes="entry-content")
 
         # Link navigation indicator (fixed height)
         link_indicator = Static("", id="link-indicator", classes="link-indicator")


### PR DESCRIPTION
## Summary
- Fixes #593 - NoMatches error when navigating between entries using J/K keys
- Added missing `id="entry-content"` to Markdown widget in entry_reader.py

## Problem
When navigating between entries using the `J/K` (uppercase) keys in the entry reader screen, the application crashed with:
```
NoMatches: No nodes match '#entry-content' on EntryReaderScreen()
```

## Root Cause
The Markdown widget in `compose()` was created with only a CSS class `entry-content`:
```python
yield Markdown(content, classes="entry-content")
```

But `refresh_screen()` attempted to query it using an ID selector:
```python
markdown_widgets = self.query_one("#entry-content", expect_type=Markdown)
```

## Solution
Added `id="entry-content"` to the Markdown widget to match the query selector:
```python
yield Markdown(content, id="entry-content", classes="entry-content")
```

## Testing
- ✅ All 1243 tests passing
- ✅ Ruff linting passed
- ✅ Pyright type checking passed (0 errors, 0 warnings)
- ✅ Code coverage maintained at 76%
- ✅ All pre-commit hooks passed

## Impact
- **Severity**: High - Application crash on basic navigation
- **Scope**: Entry reader screen navigation with J/K keys
- **Fix**: Minimal change (1 line) with zero risk of regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)