### PR TITLE
Add keyboard navigation highlighting to feed entries

### DIFF
--- a/miniflux_tui/ui/screens/entry_reader.py
+++ b/miniflux_tui/ui/screens/entry_reader.py
@@ -710,10 +710,10 @@ class EntryReaderScreen(Screen):
                 # Fallback: estimate position based on markdown content
                 # This is an approximation since we don't have exact widget positions
                 self._estimate_and_scroll_to_link(link_index)
-        except Exception:  # nosec B110
+        except Exception:  # nosec B110  # noqa: S110
             # Silently fail if scrolling isn't possible (e.g., screen not mounted)
             # This is expected in test contexts or when the widget isn't available
-            # Bandit B110: Intentional silent failure for graceful degradation
+            # Intentional silent failure for graceful degradation
             pass
 
     def _estimate_and_scroll_to_link(self, link_index: int):
@@ -758,10 +758,10 @@ class EntryReaderScreen(Screen):
                     scroll_y = max(0, y_pos - offset)
 
                     markdown_widget.scroll_to(y=scroll_y, animate=True, duration=0.3)
-        except Exception:  # nosec B110
+        except Exception:  # nosec B110  # noqa: S110
             # Silently fail if scrolling isn't possible (e.g., screen not mounted)
             # This is expected in test contexts or when the widget isn't available
-            # Bandit B110: Intentional silent failure for graceful degradation
+            # Intentional silent failure for graceful degradation
             pass
 
     def _update_link_indicator(self):


### PR DESCRIPTION
## Changes
- Added CSS styling to highlight focused links in Markdown content
- Implemented auto-scrolling to bring focused links into view
- Added support for both native Textual link widgets and fallback estimation
- Links are now highlighted with accent background when navigated with Tab/Shift+Tab
- Page automatically scrolls to show off-screen links when focused

## Implementation Details
- `_get_markdown_link_widgets()`: Query for link widgets in Markdown content
- `_scroll_to_link()`: Scroll to make focused link visible (tries native widgets first)
- `_estimate_and_scroll_to_link()`: Fallback method using content position estimation
- CSS rules for `Markdown Link:focus` and `.link-highlight` classes
- Graceful error handling for test contexts where widgets aren't mounted

## Testing
- All 113 entry reader tests pass
- Linting and type checking pass
- Silent failure in test contexts (expected behavior)

Enhances user experience by making link navigation more intuitive and visual.