### PR TITLE
fix: Pin CodeQL actions to commit SHA to resolve security alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.31.5 # v3.31.0
+        uses: github/codeql-action/init@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -54,9 +54,9 @@ jobs:
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.31.5 # v3.31.0
+        uses: github/codeql-action/autobuild@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.31.5 # v3.31.0
+        uses: github/codeql-action/analyze@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
         with:
           category: /language:${{ matrix.language }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1538,4 +1538,3 @@ Thank you to everyone who contributed to this release!
 **Humans:** 👤 Peter Reuterås
 
 **AI & Automation:** 🤖 Claude (AI Assistant)
-


### PR DESCRIPTION
## Summary

Pin all `github/codeql-action` steps in the CodeQL workflow to commit SHAs instead of version tags to improve supply chain security and resolve OpenSSF Scorecard security alerts #316, #317, and #318.

## Changes

- ✅ Pin `github/codeql-action/init@v4.31.5` to commit `fdbfb4d2750291e159f0156def62b853c2798ca2`
- ✅ Pin `github/codeql-action/autobuild@v4.31.5` to commit `fdbfb4d2750291e159f0156def62b853c2798ca2`
- ✅ Pin `github/codeql-action/analyze@v4.31.5` to commit `fdbfb4d2750291e159f0156def62b853c2798ca2`
- ✅ Auto-fix end-of-file in CHANGELOG.md (pre-commit hook)

## Security Impact

**Resolves:** Security alerts #316, #317, #318

**Risk Level:** Medium (possible compromised dependencies)

**Benefit:** By pinning GitHub Actions to specific commit hashes instead of mutable version tags, this change prevents potential supply chain attacks from compromised action versions. This follows OpenSSF best practices and improves the project's security scorecard rating.

## Testing

- ✅ YAML validation passed
- ✅ Pre-commit hooks passed
- ✅ CI/CD checks will verify on push

## Related Issues

Closes #635

## References

- [OpenSSF Scorecard - Pinned Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
- [CodeQL Action v4.31.5 Release](https://github.com/github/codeql-action/releases/tag/v4.31.5)
- [StepSecurity Secure Workflow Tool](https://app.stepsecurity.io/secureworkflow/)

🤖 Generated with Claude Code