### PR TITLE
fix: Resolve feed settings delete button and double highlight issues …

### DIFF
--- a/miniflux_tui/ui/screens/entry_list.py
+++ b/miniflux_tui/ui/screens/entry_list.py
@@ -500,14 +500,21 @@ class EntryListScreen(Screen):
 
         self.refresh_optimizer.track_full_refresh()
 
-        # Restore cursor position after list is updated
-        # This ensures cursor is initialized even when called directly (e.g., from tests)
-        # Uses call_later to defer until ListView has fully updated
-        # On initial mount, use simple positioning; otherwise restore previous position
+        # CRITICAL FIX: Set cursor position IMMEDIATELY after populating to prevent
+        # ListView from defaulting to first item (which causes double-highlight bug).
+        # Previously, we used call_later which allowed a render frame where index 0
+        # was highlighted, then the correct position was set, leaving both highlighted.
         if self._is_initial_mount:
-            self.call_later(self._set_initial_position_and_focus)
+            # On initial mount, set to first item
+            self._set_cursor_to_index(0)
+            self._safe_log("Initial mount: cursor set to first item (index 0)")
         else:
-            self.call_later(self._restore_cursor_position_and_focus)
+            # Otherwise, restore to previous position
+            self._restore_cursor_position()
+
+        # Use call_later ONLY for focus (not cursor positioning)
+        # This prevents rendering glitches while ensuring focus is set
+        self.call_later(self._ensure_focus)
 
     def _find_entry_index_by_id(self, entry_id: int | None) -> int | None:
         """Find the index of an entry by its ID.

--- a/miniflux_tui/ui/screens/feed_settings.py
+++ b/miniflux_tui/ui/screens/feed_settings.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import webbrowser
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.app import ComposeResult
@@ -28,7 +29,7 @@ class FeedSettingsScreen(Screen):
     - Network settings (authentication, proxies, certificates)
     - Rules and filtering (scraper, rewrite, blocking rules)
     - Feed metadata (last check, next check, ETag, LastModified)
-    - Feed management (delete)
+    - Feed management (delete, open in web browser)
 
     Attributes:
         feed_id: ID of the feed being configured
@@ -45,6 +46,7 @@ class FeedSettingsScreen(Screen):
         Binding("ctrl+s", "save_changes", "Save", key_display="Ctrl+S"),
         Binding("escape", "cancel_changes", "Cancel"),
         Binding("x", "open_helper", "Helper"),
+        Binding("o", "open_in_browser", "Open in Web"),
     ]
 
     DEFAULT_CSS: ClassVar[str] = """
@@ -598,6 +600,15 @@ class FeedSettingsScreen(Screen):
             value = event.value if event.value else None
             self._on_field_changed(event.select.id, value)
 
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button press events.
+
+        Args:
+            event: Button press event
+        """
+        if event.button.id == "delete-feed-button":
+            await self.action_delete_feed()
+
     async def action_focus_next(self) -> None:
         """Focus next focusable widget."""
         self.screen.focus_next()
@@ -787,6 +798,34 @@ class FeedSettingsScreen(Screen):
             docs_cache=self.docs_cache,
         )
         self.app.push_screen(helper_screen)
+
+    def action_open_in_browser(self) -> None:
+        """Open the feed in the web browser.
+
+        Opens the feed's entries page in the default web browser using the
+        Miniflux server URL and the current feed ID.
+
+        The URL format is: <SERVER_URL>/feed/<feed_id>/entries
+        """
+        # Get server URL from app config
+        if not hasattr(self.app, "config") or not self.app.config:  # type: ignore[attr-defined]
+            self._show_message("Error: App configuration not available", severity="error")
+            return
+
+        server_url = self.app.config.server_url  # type: ignore[attr-defined]
+        if not server_url:
+            self._show_message("Error: Server URL not configured", severity="error")
+            return
+
+        # Construct feed URL
+        feed_url = f"{server_url.rstrip('/')}/feed/{self.feed_id}/entries"
+
+        # Open in browser
+        try:
+            webbrowser.open(feed_url)
+            self._show_message(f"Opened in browser: {feed_url}", severity="success")
+        except Exception as e:
+            self._show_message(f"Error opening browser: {e}", severity="error")
 
     async def action_delete_feed(self) -> None:
         """Delete the feed with confirmation and visual feedback.


### PR DESCRIPTION
…(#639, #640, #642)

## Bug Fixes

### #639: Fix delete button in feed settings not responding
- Added missing `on_button_pressed` event handler
- Button.Pressed events now properly trigger `action_delete_feed`
- The action method existed but wasn't being called on button clicks

### #642: Fix double highlight bug in entry list
- Fixed timing issue where first entry and actual cursor position were both highlighted
- Changed cursor positioning to happen immediately after list population
- Previously used `call_later` which allowed a render frame with default index 0 highlight
- Now only `_ensure_focus()` is deferred, eliminating the double-highlight frame

## Features

### #640: Add 'Open in Web' option in feed settings screen
- Added keyboard binding 'o' to open feed in web browser
- Opens feed entries page: `<SERVER_URL>/feed/<feed_id>/entries`
- Uses `webbrowser.open()` with proper error handling
- Shows success/error messages via status bar

## Changes

**miniflux_tui/ui/screens/feed_settings.py:**
- Import `webbrowser` module
- Add 'o' key binding for "Open in Web"
- Add `on_button_pressed()` event handler for delete button
- Add `action_open_in_browser()` method
- Update class docstring

**miniflux_tui/ui/screens/entry_list.py:**
- Set cursor position immediately after `_display_entries()`
- Remove deferred cursor positioning from `call_later`
- Keep only `_ensure_focus()` in `call_later` for timing safety

## Testing
- All 260+ tests pass
- Linting and type checking clean
- No regressions in functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)