### PR TITLE
Remove manual monitoring for GitHub Watches

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -412,15 +412,6 @@ The project uses **Renovate** to keep dependencies up to date:
 - **Automatic approval**: Security and regular updates approved and merged when all CI checks pass
 - **Manual review**: Major version updates require your approval before merging
 
-### Manual Monitoring (GitHub Watches)
-Some critical dependencies with frequent updates should be monitored manually:
-
-1. **Trivy Action** - <https://github.com/aquasecurity/trivy-action>
-- Container vulnerability scanner
-- Watch for releases: <https://github.com/aquasecurity/trivy-action/releases>
-- Latest: `v0.33.1` (September 2025)
-- To watch: Go to repo → Click **Watch** → Select **Releases**
-
 ### Dependency Dashboard
 Check **Issue #70** for the Renovate Dependency Dashboard:
 - Shows all pending updates


### PR DESCRIPTION
Removed manual monitoring section for critical dependencies.