### PR TITLE
fix: replace asyncio.create_task with run_worker to prevent GC of fire-and-forget tasks

### DIFF
--- a/miniflux_tui/ui/screens/category_management.py
+++ b/miniflux_tui/ui/screens/category_management.py
@@ -2,7 +2,6 @@
 """Category management screen for viewing and managing categories."""
 
 # pylint: disable=no-value-for-parameter
-import asyncio
 from typing import TYPE_CHECKING, ClassVar
 
 from textual.app import ComposeResult
@@ -168,7 +167,7 @@ class CategoryManagementScreen(Screen):
                 self.app.notify("Category name cannot be empty", severity="error")
                 return
 
-            asyncio.create_task(self._do_create_category(title.strip()))  # noqa: RUF006
+            self.run_worker(self._do_create_category(title.strip()), exclusive=True)
 
         dialog = InputDialog(
             title="Create Category",
@@ -209,7 +208,7 @@ class CategoryManagementScreen(Screen):
                 self.app.notify("Category name cannot be empty", severity="error")
                 return
 
-            asyncio.create_task(self._do_edit_category(selected.id, new_title.strip()))  # noqa: RUF006
+            self.run_worker(self._do_edit_category(selected.id, new_title.strip()), exclusive=True)
 
         dialog = InputDialog(
             title="Edit Category",
@@ -252,7 +251,7 @@ class CategoryManagementScreen(Screen):
 
         def on_confirm() -> None:
             """Handle deletion confirmation."""
-            asyncio.create_task(self._do_delete_category(selected.id, selected.title))  # noqa: RUF006
+            self.run_worker(self._do_delete_category(selected.id, selected.title), exclusive=True)
 
         dialog = ConfirmDialog(
             title="Delete Category?",

--- a/miniflux_tui/ui/screens/entry_list.py
+++ b/miniflux_tui/ui/screens/entry_list.py
@@ -1499,7 +1499,7 @@ class EntryListScreen(Screen):
 
         def on_confirm() -> None:
             """Handle confirmation to mark all as read."""
-            asyncio.create_task(self._do_mark_all_as_read())  # noqa: RUF006
+            self.run_worker(self._do_mark_all_as_read(), exclusive=True)
 
         # Create confirmation dialog
         dialog = ConfirmDialog(

--- a/miniflux_tui/ui/screens/feed_management.py
+++ b/miniflux_tui/ui/screens/feed_management.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 """Feed management screen for viewing and managing feeds."""
 
-import asyncio
 from typing import ClassVar
 
 from textual.app import ComposeResult
@@ -154,7 +153,7 @@ class FeedManagementScreen(Screen):
                 return
 
             # Create feed in background
-            asyncio.create_task(self._create_feed(url))  # noqa: RUF006
+            self.run_worker(self._create_feed(url), exclusive=True)
 
         self.app.push_screen(
             InputDialog(
@@ -198,7 +197,7 @@ class FeedManagementScreen(Screen):
             return
 
         def on_confirm() -> None:
-            asyncio.create_task(self._do_delete_feed(feed))  # noqa: RUF006
+            self.run_worker(self._do_delete_feed(feed), exclusive=True)
 
         self.app.push_screen(
             ConfirmDialog(


### PR DESCRIPTION
asyncio.create_task() can be garbage-collected before completion if no
reference is kept (RUF006 / the Textual "Heisenbug"). Replace all 6
occurrences with self.run_worker(), which is Textual's built-in mechanism
for background tasks and already the established pattern in this codebase.

Also remove the now-unused `import asyncio` from category_management.py
and feed_management.py.

https://claude.ai/code/session_0172uWyjYykznQzjGRBWNyXM