### PR TITLE
fix: Remediate security findings from audit

### DIFF
--- a/miniflux_tui/api/client.py
+++ b/miniflux_tui/api/client.py
@@ -2,10 +2,12 @@
 """Miniflux API client wrapper using official miniflux package."""
 
 import asyncio
+import warnings
 from collections.abc import Callable
 from functools import partial
 from typing import TypeVar
 
+import requests
 from miniflux import Client as MinifluxClientBase
 
 from miniflux_tui.constants import BACKOFF_FACTOR, MAX_RETRIES
@@ -31,16 +33,29 @@ class MinifluxClient:
         Args:
             base_url: Base URL of the Miniflux server
             api_key: API key for authentication
-            allow_invalid_certs: Whether to allow invalid SSL certificates (not supported by official client)
+            allow_invalid_certs: Whether to allow invalid SSL certificates (e.g. self-signed certs).
+                When True a custom requests.Session with verify=False is passed to the client.
             timeout: Request timeout in seconds (not supported by official client)
         """
         self.base_url = base_url.rstrip("/")
 
-        # Create official Miniflux client (synchronous)
-        # The official client expects api_key as a keyword argument
-        self.client = MinifluxClientBase(base_url, api_key=api_key)
+        # Create official Miniflux client (synchronous).
+        # When the user opts in to allow_invalid_certs (e.g. self-signed cert
+        # behind Tailscale), pass a custom Session with verify=False.
+        # We suppress urllib3's InsecureRequestWarning because the user made
+        # an explicit, informed configuration choice.
+        if allow_invalid_certs:
+            session = requests.Session()
+            session.verify = False
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                import urllib3  # noqa: PLC0415
 
-        # Allow invalid certs
+                urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            self.client = MinifluxClientBase(base_url, api_key=api_key, session=session)
+        else:
+            self.client = MinifluxClientBase(base_url, api_key=api_key)
+
         self.allow_invalid_certs: bool = allow_invalid_certs
 
         # Timeout for network calls

--- a/miniflux_tui/docs_fetcher.py
+++ b/miniflux_tui/docs_fetcher.py
@@ -7,6 +7,7 @@ import re
 from html.parser import HTMLParser
 
 import httpx
+from bs4 import BeautifulSoup
 
 # Mapping of rule types to their documentation anchors
 RULE_TYPES = {
@@ -68,11 +69,16 @@ class DocsFetcher:
             Raw HTML content
 
         Raises:
+            ValueError: If the response Content-Type is not HTML
             Exception: Network errors or HTTP errors
         """
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.get(DOCS_URL)
             response.raise_for_status()
+            content_type = response.headers.get("content-type", "")
+            if "text/html" not in content_type:
+                msg = f"Unexpected content type from docs URL: {content_type!r}"
+                raise ValueError(msg)
             return response.text
 
     def _extract_section(self, html: str, anchor: str, rule_type: str) -> str:
@@ -177,22 +183,32 @@ class HTMLContentParser(HTMLParser):
 def _sanitize_html(html: str) -> str:
     """Sanitize HTML to prevent XSS when displaying in TUI.
 
+    Uses BeautifulSoup to remove dangerous tags and attributes rather than
+    fragile regex patterns that can be bypassed with case variations,
+    entity encoding, or extra whitespace.
+
     Args:
         html: Raw HTML content
 
     Returns:
-        Sanitized HTML
+        Sanitized HTML with dangerous elements removed
     """
-    # Remove potentially dangerous tags and attributes
-    dangerous_patterns = [
-        r"<script[^>]*>.*?</script>",  # Remove script tags
-        r"<iframe[^>]*>.*?</iframe>",  # Remove iframes
-        r"on\w+\s*=",  # Remove event handlers
-        r"javascript:",  # Remove javascript: protocol
-    ]
+    dangerous_tags = frozenset({"script", "iframe", "object", "embed", "applet"})
+    url_attrs = frozenset({"href", "src", "action", "formaction", "data"})
 
-    sanitized = html
-    for pattern in dangerous_patterns:
-        sanitized = re.sub(pattern, "", sanitized, flags=re.IGNORECASE | re.DOTALL)
+    soup = BeautifulSoup(html, "html.parser")
 
-    return sanitized
+    for tag in soup.find_all(dangerous_tags):
+        tag.decompose()
+
+    for tag in soup.find_all(True):
+        for attr in list(tag.attrs):
+            lower_attr = attr.lower()
+            if lower_attr.startswith("on"):
+                del tag.attrs[attr]
+            elif lower_attr in url_attrs:
+                val = str(tag.get(attr, "")).strip().lower()
+                if val.startswith(("javascript:", "vbscript:")):
+                    del tag.attrs[attr]
+
+    return str(soup)

--- a/miniflux_tui/draft_manager.py
+++ b/miniflux_tui/draft_manager.py
@@ -82,7 +82,7 @@ class DraftManager:
         """
         config_dir = Path(get_config_dir())
         self.drafts_dir = config_dir / "drafts"
-        self.drafts_dir.mkdir(parents=True, exist_ok=True)
+        self.drafts_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
     def save_draft(self, feed_id: int, field_values: dict[str, Any]) -> Draft:
         """Save a draft of feed settings.
@@ -107,6 +107,7 @@ class DraftManager:
         draft_file = self._get_draft_file(feed_id)
         try:
             draft_file.write_text(json.dumps(draft.to_dict(), indent=2), encoding="utf-8")
+            draft_file.chmod(0o600)
             return draft
         except OSError as e:
             msg = f"Failed to save draft for feed {feed_id}: {e}"

--- a/miniflux_tui/security.py
+++ b/miniflux_tui/security.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Security utilities for input validation and sanitization."""
 
+import ipaddress
 import re
 from urllib.parse import urlparse
 
@@ -46,41 +47,51 @@ def _check_url_hostname(parsed) -> str | None:
     Returns:
         Error message if invalid, None if valid
     """
-    # Extract hostname without port
-    hostname = parsed.netloc.split(":")[0].lower()
+    # Use parsed.hostname which correctly strips IPv6 brackets and lowercases.
+    # parsed.netloc.split(":") is wrong for IPv6 (e.g. "[fd00::1]" → "[fd00").
+    hostname = parsed.hostname or ""
 
-    # Block localhost/loopback addresses
-    if hostname in ["localhost", "127.0.0.1", "::1", "[::1]"]:
+    # Block localhost by name
+    if hostname == "localhost":
         return "Cannot add local URLs (localhost)"
 
-    # Block private IP ranges
+    # Block all private/reserved IP addresses (covers loopback, ULA, link-local,
+    # multicast, carrier-grade NAT, etc.) using the stdlib ipaddress module.
     if _is_private_ip(hostname):
         return "Cannot add private network URLs"
-
-    # Block IPv6 loopback and link-local
-    if hostname.startswith(("fe80:", "[fe80:")):
-        return "Cannot add link-local IPv6 addresses"
 
     return None
 
 
+# RFC 6598 Shared Address Space (100.64.0.0/10) is used for carrier-grade NAT
+# and is not classified by Python's ipaddress as is_private / is_reserved in
+# Python 3.13. Check it explicitly.
+_ADDITIONAL_RESERVED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (ipaddress.IPv4Network("100.64.0.0/10"),)
+
+
 def _is_private_ip(hostname: str) -> bool:
-    """Check if hostname is a private IP address.
+    """Check if hostname is a private or reserved IP address.
+
+    Uses the stdlib ipaddress module instead of regex patterns so that
+    IPv4-mapped IPv6, ULA (fd00::/8), multicast, carrier-grade NAT, and
+    other reserved ranges are all covered correctly.
 
     Args:
-        hostname: The hostname/IP to check
+        hostname: The hostname/IP to check (IPv6 brackets already stripped
+            by urlparse.hostname)
 
     Returns:
-        True if hostname is a private IP, False otherwise
+        True if hostname is a private/reserved IP, False otherwise
     """
-    private_patterns = [
-        r"^192\.168\.",
-        r"^10\.",
-        r"^172\.(1[6-9]|2[0-9]|3[01])\.",  # 172.16.0.0 - 172.31.255.255
-        r"^127\.",  # Loopback
-        r"^169\.254\.",  # Link-local
-    ]
-    return any(re.match(pattern, hostname) for pattern in private_patterns)
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_multicast or addr.is_reserved or addr.is_unspecified:
+            return True
+        return any(addr in net for net in _ADDITIONAL_RESERVED_NETWORKS)
+    except ValueError:
+        # Not a valid IP literal — it is a hostname; DNS-based access is
+        # controlled server-side by Miniflux itself.
+        return False
 
 
 def _check_url_suspicious_content(url: str) -> str | None:

--- a/miniflux_tui/ui/screens/entry_reader.py
+++ b/miniflux_tui/ui/screens/entry_reader.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from urllib.parse import urlparse
 
 import html2text
+from bs4 import BeautifulSoup
 from textual.app import ComposeResult
 from textual.binding import Binding
 
@@ -381,6 +382,57 @@ class EntryReaderScreen(Screen):
                 self.log(traceback.format_exc())
                 self.notify(f"Error marking as read: {e}", severity="error")
 
+    @staticmethod
+    def _sanitize_feed_html(html_content: str) -> str:
+        """Strip dangerous tags and attributes from untrusted feed HTML.
+
+        RSS feed content is untrusted input. Before passing to html2text we
+        remove elements that could embed terminal escape sequences or other
+        harmful payloads in the rendered output.
+
+        Args:
+            html_content: Raw HTML from an RSS entry
+
+        Returns:
+            HTML with dangerous tags and attributes removed
+        """
+        dangerous_tags = frozenset(
+            {
+                "script",
+                "style",
+                "iframe",
+                "object",
+                "embed",
+                "form",
+                "meta",
+                "link",
+                "base",
+                "noscript",
+                "applet",
+                "frame",
+                "frameset",
+            }
+        )
+        url_attrs = frozenset({"href", "src", "action", "formaction", "data"})
+
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        for tag in soup.find_all(dangerous_tags):
+            tag.decompose()
+
+        for tag in soup.find_all(True):
+            for attr in list(tag.attrs):
+                lower_attr = attr.lower()
+                # Remove all event-handler attributes (onclick, onload, …)
+                if lower_attr.startswith("on"):
+                    del tag.attrs[attr]
+                elif lower_attr in url_attrs:
+                    val = str(tag.get(attr, "")).strip().lower()
+                    if val.startswith(("javascript:", "vbscript:", "data:")):
+                        del tag.attrs[attr]
+
+        return str(soup)
+
     def _html_to_markdown(self, html_content: str) -> str:
         """Convert HTML content to markdown for display.
 
@@ -393,6 +445,7 @@ class EntryReaderScreen(Screen):
         Returns:
             Markdown-formatted string suitable for terminal display
         """
+        sanitized = self._sanitize_feed_html(html_content)
         h = html2text.HTML2Text()
         # Preserve links, images, and emphasis in the output
         h.ignore_links = False
@@ -400,7 +453,7 @@ class EntryReaderScreen(Screen):
         h.ignore_emphasis = False
         # Control wrapping: 0 = let Textual handle terminal wrapping, >0 = wrap at configured width
         h.body_width = self.text_width
-        return h.handle(html_content)
+        return h.handle(sanitized)
 
     @staticmethod
     def _extract_links(markdown_content: str) -> list[dict[str, str]]:
@@ -524,7 +577,13 @@ class EntryReaderScreen(Screen):
         if not parsed.netloc:
             return False
 
-        return not any(ord(char) < 32 for char in url)
+        # Reject literal control characters
+        if any(ord(char) < 32 for char in url):
+            return False
+
+        # Reject percent-encoded null byte, which some platforms pass through
+        # to the underlying shell invocation used by webbrowser.open()
+        return "%00" not in url.lower()
 
     def action_open_browser(self):
         """Open entry URL in web browser."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "html5lib>=1.1",
     "bleach>=6.3.0",
     "httpx>=0.28.1",
+    "requests>=2.32.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -42,10 +42,10 @@ class TestURLValidation:
         assert "local" in error.lower()
 
     def test_reject_127_0_0_1(self) -> None:
-        """Test 127.0.0.1 URLs are rejected."""
+        """Test 127.0.0.1 URLs are rejected (loopback → private network)."""
         is_valid, error = validate_feed_url("http://127.0.0.1:8080")
         assert is_valid is False
-        assert "local" in error.lower()
+        assert "local" in error.lower() or "private" in error.lower()
 
     def test_reject_private_ip_192_168(self) -> None:
         """Test 192.168.x.x URLs are rejected."""
@@ -68,10 +68,38 @@ class TestURLValidation:
     def test_reject_link_local_ipv6(self) -> None:
         """Test link-local IPv6 URLs are rejected."""
         is_valid, error = validate_feed_url("http://[fe80::1]")
-        # IPv6 hostnames in brackets may be accepted, but we verify it's handled
-        # This is a lower priority security concern than SSRF to private networks
-        if not is_valid:
-            assert "link-local" in error.lower() or "invalid" in error.lower()
+        assert is_valid is False
+        assert "private" in error.lower()
+
+    def test_reject_ipv6_loopback(self) -> None:
+        """Test IPv6 loopback ::1 is rejected."""
+        is_valid, error = validate_feed_url("http://[::1]/feed")
+        assert is_valid is False
+        assert "private" in error.lower()
+
+    def test_reject_ipv6_ula(self) -> None:
+        """Test IPv6 Unique Local Addresses (fd00::/8) are rejected."""
+        is_valid, error = validate_feed_url("http://[fd00::1]/feed")
+        assert is_valid is False
+        assert "private" in error.lower()
+
+    def test_reject_ipv6_ula_fc(self) -> None:
+        """Test IPv6 Unique Local Addresses (fc00::/7) are rejected."""
+        is_valid, error = validate_feed_url("http://[fc00::1]/feed")
+        assert is_valid is False
+        assert "private" in error.lower()
+
+    def test_reject_ipv4_multicast(self) -> None:
+        """Test IPv4 multicast addresses (224.0.0.0/4) are rejected."""
+        is_valid, error = validate_feed_url("http://224.0.0.1/feed")
+        assert is_valid is False
+        assert "private" in error.lower()
+
+    def test_reject_carrier_grade_nat(self) -> None:
+        """Test carrier-grade NAT addresses (100.64.0.0/10) are rejected."""
+        is_valid, error = validate_feed_url("http://100.64.0.1/feed")
+        assert is_valid is False
+        assert "private" in error.lower()
 
     def test_reject_overlong_url(self) -> None:
         """Test extremely long URLs are rejected."""

--- a/uv.lock
+++ b/uv.lock
@@ -648,6 +648,7 @@ dependencies = [
     { name = "html5lib" },
     { name = "httpx" },
     { name = "miniflux" },
+    { name = "requests" },
     { name = "textual" },
 ]
 
@@ -717,6 +718,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "textual", specifier = ">=6.4.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },


### PR DESCRIPTION
## Summary

Fixes 7 security findings (2 High, 3 Medium, 2 Low) identified in a security audit of untrusted RSS feed input handling. No deprecated libraries introduced — sanitization uses BeautifulSoup and stdlib `ipaddress`, both already present in the dependency tree.

- **HIGH**: `entry_reader.py` — add `_sanitize_feed_html()` using BeautifulSoup to strip dangerous tags, `on*` event handlers, and `javascript:`/`vbscript:` URLs before `html2text` conversion. Also block `%00` in `_is_safe_external_url()`.
- **HIGH**: `security.py` — replace regex IP matching with stdlib `ipaddress`. Fix IPv6 bracket parsing bug (`parsed.hostname` instead of `netloc.split(":")[0]`) that allowed `[fd00::1]` to bypass all private-range checks. Now covers loopback, ULA, link-local, multicast, reserved, unspecified, and carrier-grade NAT (100.64.0.0/10 explicit check needed for Python 3.13).
- **MEDIUM**: `api/client.py` — implement `allow_invalid_certs` properly: was silently ignored, now passes a `requests.Session(verify=False)` to the client. Add `requests` as an explicit dependency.
- **MEDIUM**: `docs_fetcher.py` — replace regex `_sanitize_html()` with BeautifulSoup (regex bypassed by case/entity/whitespace variants). Add `Content-Type: text/html` validation on fetched docs response.
- **LOW**: `draft_manager.py` — `mkdir(mode=0o700)` and `chmod(0o600)` on draft files to prevent world-readable settings under a permissive umask.

## Test plan

- [ ] 1293 tests pass (`uv run pytest tests/`)
- [ ] 0 lint errors (`uv run ruff check .`)
- [ ] 0 type errors (`uv run pyright`)
- [ ] All pre-commit hooks pass
- [ ] 6 new IPv6/CGN test cases in `test_security.py`
- [ ] All existing `test_docs_fetcher.py` sanitization tests pass with BeautifulSoup impl

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)